### PR TITLE
Extend appveyor rules

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -9,5 +9,5 @@ main = do
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
         system_ "cabal build"
-        system_ "cabal new-install"
+        system_ "cabal install --verbose=3"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,8 +7,7 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal configure --disable-library-profiling --disable-optimisation"
-        system_ "cabal build lib:ghc-lib"
-        system_ "cabal build exe:ghc-lib"
+        system_ "cabal configure -fwith-heap-prim --disable-library-profiling --disable-optimisation"
+        system_ "cabal build "
         system_ "cabal install --verbose=1"
     withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -11,3 +11,6 @@ main = do
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
         system_ "cabal build lib:ghc-lib"
+        system_ "cabal build lib:ghc-lib"
+        system_ "cabal install"
+    withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,7 +7,7 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal configure --disable-library-profiling --disable-optimisation"
-        system_ "cabal build"
-        system_ "cabal install"
+        system_ "cabal new-configure --disable-library-profiling --disable-optimisation"
+        system_ "cabal new-build"
+        system_ "cabal new-install"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,7 +7,8 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal configure" -- --disable-library-profiling --disable-optimisation
+        system_ "cabal configure"
         system_ "cabal build"
         system_ "cabal install --verbose=3"
-    -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"
+    withCurrentDirectory "examples/mini-hlint" $
+        system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -11,4 +11,4 @@ main = do
         system_ "cabal build lib:ghc-lib"
         system_ "cabal build exe:ghc-lib"
         system_ "cabal install --verbose=1"
-    -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"
+    withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -10,6 +10,7 @@ main = do
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
-        system_ "cabal build lib:ghc-lib"
+        -- system_ "cabal build lib:ghc-lib"
+        system_ "cabal build"
         system_ "cabal install --verbose=3"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -1,7 +1,5 @@
-
 import System.Directory
 import System.Process.Extra
-
 
 main :: IO ()
 main = do
@@ -10,7 +8,7 @@ main = do
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
-        -- system_ "cabal build lib:ghc-lib"
-        system_ "cabal build"
-        system_ "cabal install --verbose=3"
+        system_ "cabal build lib:ghc-lib"
+        system_ "cabal build exe:ghc-lib"
+        system_ "cabal install --verbose=1"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -9,6 +9,6 @@ main = do
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure"
         system_ "cabal build"
-        system_ "cabal install --verbose=3"
+        system_ "cabal install"
     withCurrentDirectory "examples/mini-hlint" $
-        system_ "cabal run mini-hlint test/MiniHlintTest.hs"
+        system_ "cabal test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,7 +7,7 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal new-configure --disable-library-profiling --disable-optimisation"
+        system_ "cabal configure --disable-library-profiling --disable-optimisation"
         system_ "cabal build"
     --     -- system_ "cabal install --verbose=1"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -11,4 +11,4 @@ main = do
         system_ "cabal build"
         system_ "cabal install"
     withCurrentDirectory "examples/mini-hlint" $
-        system_ "cabal test/MiniHlintTest.hs"
+        system_ "cabal mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -11,4 +11,4 @@ main = do
         system_ "cabal build"
         system_ "cabal install"
     withCurrentDirectory "examples/mini-hlint" $
-        system_ "cabal mini-hlint test/MiniHlintTest.hs"
+        system_ "cabal run test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -11,6 +11,5 @@ main = do
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
         system_ "cabal build lib:ghc-lib"
-        system_ "cabal build lib:ghc-lib"
-        system_ "cabal install"
-    withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"
+        system_ "cabal install --verobse=3"
+    -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,7 +7,7 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal new-configure --disable-library-profiling --disable-optimisation"
-        system_ "cabal new-build"
+        system_ "cabal configure --disable-library-profiling --disable-optimisation"
+        system_ "cabal build"
         system_ "cabal new-install"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,7 +7,7 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal configure --disable-library-profiling --disable-optimisation"
+        system_ "cabal configure" -- --disable-library-profiling --disable-optimisation
         system_ "cabal build"
         system_ "cabal install --verbose=3"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -9,5 +9,5 @@ main = do
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
         system_ "cabal build"
-    --     -- system_ "cabal install --verbose=1"
+        system_ "cabal install"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -11,5 +11,5 @@ main = do
     withCurrentDirectory "ghc" $ do
         system_ "cabal configure --disable-library-profiling --disable-optimisation"
         system_ "cabal build lib:ghc-lib"
-        system_ "cabal install --verobse=3"
+        system_ "cabal install --verbose=3"
     -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"

--- a/CI.hs
+++ b/CI.hs
@@ -7,7 +7,7 @@ main = do
     system_ "curl -sSL https://get.haskellstack.org/ | sh" -- we'd like to use Cabal
     withCurrentDirectory "ghc-lib-gen" $ system_ "cabal run ../ghc"
     withCurrentDirectory "ghc" $ do
-        system_ "cabal configure -fwith-heap-prim --disable-library-profiling --disable-optimisation"
-        system_ "cabal build "
-        system_ "cabal install --verbose=1"
-    withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"
+        system_ "cabal new-configure --disable-library-profiling --disable-optimisation"
+        system_ "cabal build"
+    --     -- system_ "cabal install --verbose=1"
+    -- withCurrentDirectory "examples/mini-hlint" $ system_ "cabal run mini-hlint test/MiniHlintTest.hs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,5 +28,6 @@ test_script:
 - echo - examples/mini-hlint >> stack.yaml
 - echo - ghc >> stack.yaml
 # Build ghc-lib and exec mini-hlint
-- stack build --flag ghc-lib:-build-exe
-- stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs
+#- stack build --flag ghc-lib:-build-exe
+- stack build --flag ghc-lib:with-heap-prim
+# - stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,15 @@ test_script:
 - stack init ghc-lib-gen --resolver=lts-12.10
 - stack setup > nul
 - stack exec -- pacman -S autoconf automake-wrapper make patch python tar --noconfirm
+# Build ghc-lib-gen
 - echo "" | stack --no-terminal build ghc-lib-gen
+# Clone ghc and exec ghc-lib-gen on it
 - git clone git://git.haskell.org/ghc.git --recursive
 - stack exec -- ghc-lib-gen ghc
 # stack init doesn't work because of https://github.com/commercialhaskell/stack/issues/4508
+# Set up stack configs for ghc -lib and mini-hlint
 - echo - examples/mini-hlint >> stack.yaml
 - echo - ghc >> stack.yaml
-# - stack build --flag ghc-lib:with-heap-prim --flag ghc-lib:-build-exe
-# - stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs
+# Build ghc-lib and exec mini-hlint
+- stack build --flag ghc-lib:-build-exe
+- stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,5 @@ test_script:
 - echo - examples/mini-hlint >> stack.yaml
 - echo - ghc >> stack.yaml
 # Build ghc-lib and exec mini-hlint
-#- stack build --flag ghc-lib:-build-exe
 - stack build
-# - stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs
+- stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,5 +29,5 @@ test_script:
 - echo - ghc >> stack.yaml
 # Build ghc-lib and exec mini-hlint
 #- stack build --flag ghc-lib:-build-exe
-- stack build --flag ghc-lib:with-heap-prim
+- stack build
 # - stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -329,6 +329,9 @@ genCabal root = do
         , "        ghc-lib"
         , "    if !flag(build-exe)"
         , "        buildable: False"
+        , "    if flag(with-heap-prim)"
+        , "        extra-lib-dirs: ghc-lib/stage0/libraries/ghc-heap/build/cmm/cbits"
+        , "        extra-libraries: HeapPrim"
         , "    hs-source-dirs: ghc"
         , "    ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
         , "    cc-options: -DTHREADED_RTS"
@@ -336,6 +339,7 @@ genCabal root = do
         ])
        ++ "    other-modules:\n" ++ (concat eom')
        ++ "    other-extensions:\n" ++ (concat eoe')
+       ++ "    c-sources:\n"          ++ (concat csf')
        ++ (unlines [
           "    default-extensions: NoImplicitPrelude"
         , "    main-is: Main.hs"

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -86,6 +86,31 @@ dataFiles =
   , "platformConstants"
   ]
 
+-- |'appPatchHeapClosures' stubs out a couple of definitions on a
+-- particular file in the ghc-heap library.
+appPatchHeapClosures :: FilePath -> IO ()
+appPatchHeapClosures root =
+  do
+    s <- readFile' src
+    writeFile src $ fromMaybe s ((fixaToWord >=> fixReallyUnsafePtrEqualityUpToTag) s)
+  where
+      src = root </> "libraries/ghc-heap/GHC/Exts/Heap/Closures.hs"
+      aToWord ="foreign import prim \"aToWordzh\" aToWord# :: Any -> Word#"
+      reallyUnsafePtrEqualityUpToTag="foreign import prim \"reallyUnsafePtrEqualityUpToTag\"\n    reallyUnsafePtrEqualityUpToTag# :: Any -> Any -> Int#"
+
+      fixaToWord s =
+        case stripInfix aToWord s of
+          Nothing -> Nothing
+          Just (b, rest) ->
+            Just (b ++ "aToWord# :: Any -> Word#\naToWord# _ = 0##\n" ++ rest)
+
+      fixReallyUnsafePtrEqualityUpToTag s =
+        case stripInfix reallyUnsafePtrEqualityUpToTag s of
+          Nothing -> Nothing
+          Just (b, rest) ->
+            Just (b
+                  ++ "reallyUnsafePtrEqualityUpToTag# :: Any -> Any -> Int#\nreallyUnsafePtrEqualityUpToTag# _ _ = 0#\n" ++ rest)
+
 -- Functions for generating files.
 
 -- |'harvest' finds all entries for a given section in the text of a
@@ -190,6 +215,7 @@ hsSourceDirs root =
   in do
        files <- withCabals f root
        return $ ("ghc-lib/stage1/compiler/build") : files
+
 
 -- |'exeOtherExtensions' extracts a list of "other-extensions" from the GHC
 -- as an exe cabal file.
@@ -392,6 +418,7 @@ genPrerequisites root = do
 main :: IO ()
 main = do
   [root] <- getArgs
+  appPatchHeapClosures root
   genStackYaml root
   genPrerequisites root
   genCabal root

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -355,9 +355,6 @@ genCabal root = do
         , "        ghc-lib"
         , "    if !flag(build-exe)"
         , "        buildable: False"
-        , "    if flag(with-heap-prim)"
-        , "        extra-lib-dirs: ghc-lib/stage0/libraries/ghc-heap/build/cmm/cbits"
-        , "        extra-libraries: HeapPrim"
         , "    hs-source-dirs: ghc"
         , "    ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
         , "    cc-options: -DTHREADED_RTS"
@@ -365,7 +362,6 @@ genCabal root = do
         ])
        ++ "    other-modules:\n" ++ (concat eom')
        ++ "    other-extensions:\n" ++ (concat eoe')
-       ++ "    c-sources:\n"          ++ (concat csf')
        ++ (unlines [
           "    default-extensions: NoImplicitPrelude"
         , "    main-is: Main.hs"


### PR DESCRIPTION
This PR adds rules to Travis and Appveyor for building the `ghc-lib` exe, the `mini-hlint` exe and execution of its test.  