### PR TITLE
ghc-lib-exe-test : add a test for ghc-lib exe

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -10,5 +10,7 @@ main = do
         system_ "cabal configure"
         system_ "cabal build"
         system_ "cabal install"
+    withCurrentDirectory "ghc" $
+        system_ "cabal run -- --version"
     withCurrentDirectory "examples/mini-hlint" $
         system_ "cabal run test/MiniHlintTest.hs"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ test_script:
 # Set up stack configs for ghc -lib and mini-hlint
 - echo - examples/mini-hlint >> stack.yaml
 - echo - ghc >> stack.yaml
-# Build ghc-lib and exec mini-hlint
+# Build ghc-lib and exec tests
 - stack build
+- stack exec -- ghc-lib --version
 - stack exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs


### PR DESCRIPTION
This PR adds a tiny test of the `ghc-lib` executable to CI.