### PR TITLE
stack-runhaskell-test : see if exec is uneeded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ script:
 - curl -sSL https://get.haskellstack.org/ | sh
 - stack setup > nul
 - stack --no-terminal build ghc-lib-gen
-- stack exec runhaskell CI.hs
+- stack runhaskell CI.hs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,4 +15,4 @@ test_script:
 
 - stack setup > nul
 - stack --no-terminal build ghc-lib-gen
-- stack exec runhaskell CI.hs
+- stack runhaskell CI.hs


### PR DESCRIPTION
This PR removes the `exec` from the `runhaskell` command invocations.