### PR TITLE
Bump cabal again

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -139,7 +139,7 @@ generateCabal = do
     let indent2 = indent . indent
     writeFile "ghc-lib.cabal" $ unlines $ map trimEnd $
         -- header
-        ["cabal-version: 3.0" -- contains cmm-sources
+        ["cabal-version: 2.2"
         ,"build-type: Simple"
         ,"name: ghc-lib"
         ,"version: 0.1.0"
@@ -205,8 +205,6 @@ generateCabal = do
         indent2 (askField lib "other-extensions:") ++
         ["    c-sources:"] ++
         indent2 (askFiles lib "c-sources:") ++
-        ["    cmm-sources:"] ++
-        indent2 (askFiles lib "cmm-sources:") ++
         ["    hs-source-dirs:"] ++
         indent2 (nubSort $
             "ghc-lib/stage1/compiler/build" :

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -139,7 +139,7 @@ generateCabal = do
     let indent2 = indent . indent
     writeFile "ghc-lib.cabal" $ unlines $ map trimEnd $
         -- header
-        ["cabal-version: 2.2"
+        ["cabal-version: 1.12"
         ,"build-type: Simple"
         ,"name: ghc-lib"
         ,"version: 0.1.0"

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -139,7 +139,7 @@ generateCabal = do
     let indent2 = indent . indent
     writeFile "ghc-lib.cabal" $ unlines $ map trimEnd $
         -- header
-        ["cabal-version: 2.2" -- or cabal check complains about cmm-sources
+        ["cabal-version: 3.0" -- contains cmm-sources
         ,"build-type: Simple"
         ,"name: ghc-lib"
         ,"version: 0.1.0"

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -205,6 +205,8 @@ generateCabal = do
         indent2 (askField lib "other-extensions:") ++
         ["    c-sources:"] ++
         indent2 (askFiles lib "c-sources:") ++
+        -- ["    cmm-sources:"] ++
+        -- indent2 (askFiles lib "cmm-sources:") ++
         ["    hs-source-dirs:"] ++
         indent2 (nubSort $
             "ghc-lib/stage1/compiler/build" :


### PR DESCRIPTION
This PR comments out `cmm-sources` and drops the cabal version back to `1.2`.