### PR TITLE
license-fix : hackage won't accept if not BSD3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ghc/
 ghc-master/
 .stack-work/
 *.hi
+.DS_Store
+*.tar.gz

--- a/examples/mini-compile/mini-compile.cabal
+++ b/examples/mini-compile/mini-compile.cabal
@@ -1,7 +1,7 @@
 name:                mini-compile
 version:             0.1.0.0
 license:             BSD3
-x-license:           BSD-3-Clause OR Apache-2.0
+x-license:           BSD3-Clause OR Apache-2.0
 license-file:        ../../LICENSE
 author:              Shayne Fletcher (shayne.fletcher@digitalasset.com)
 maintainer:          Shayne Fletcher (shayne.fletcher@digitalasset.com)

--- a/examples/mini-hlint/mini-hlint.cabal
+++ b/examples/mini-hlint/mini-hlint.cabal
@@ -1,7 +1,7 @@
 name:                mini-hlint
 version:             0.1.0.0
 license:             BSD3
-x-license:           BSD-3-Clause OR Apache-2.0
+x-license:           BSD3-Clause OR Apache-2.0
 license-file:        ../../LICENSE
 author:              Shayne Fletcher (shayne.fletcher@digitalasset.com)
 maintainer:          Shayne Fletcher (shayne.fletcher@digitalasset.com)

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -143,7 +143,7 @@ generateCabal = do
         ,"build-type: Simple"
         ,"name: ghc-lib"
         ,"version: 0.1.0"
-        ,"license: BSD"
+        ,"license: BSD3"
         ,"license-file: LICENSE"
         ,"category: Development"
         ,"author: The GHC Team and Digital Asset"

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -143,7 +143,7 @@ generateCabal = do
         ,"build-type: Simple"
         ,"name: ghc-lib"
         ,"version: 0.1.0"
-        ,"license: BSD-3-Clause"
+        ,"license: BSD"
         ,"license-file: LICENSE"
         ,"category: Development"
         ,"author: The GHC Team and Digital Asset"


### PR DESCRIPTION
This PR affects slightly the license string in the generated cabal. This is to satisfy hackage requirements.