### PR TITLE
default-hide-package : hide package by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ While `ghc-lib` provides the full GHC API, it doesn't contain a runtime system, 
 
 ## Using `ghc-lib`
 
-The package `ghc-lib` is available on [Hackage](https://hackage.haskell.org/), and can be used like any normal package, e.g. `cabal install ghc-lib`. Since `ghc-lib` conflicts perfectly with the GHC API and [`template-haskell`](https://hackage.haskell.org/package/template-haskell), you may wish to [`ghc-pkg hide ghc-lib`](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#using-packages) and use the language extension `PackageImports` to do `import "ghc-lib" GHC`. There are two release streams within the `ghc-lib` name:
+The package `ghc-lib` is available on [Hackage](https://hackage.haskell.org/), and can be used like any normal package, e.g. `cabal install ghc-lib`. Since `ghc-lib` conflicts perfectly with the GHC API and [`template-haskell`](https://hackage.haskell.org/package/template-haskell), the package is [hidden by default](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/packages.html#using-packages) : use the language extension `PackageImports` to do `import "ghc-lib" GHC`. There are two release streams within the `ghc-lib` name:
 
 * Version 8.8.1 is the version of `ghc-lib` produced against the released GHC 8.8.1.
 * Version 0.20190127 is the version of `ghc-lib` using GHC HEAD on the date 2019-01-27.

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -152,6 +152,7 @@ generateCabal = do
         ,"description: A package equivalent to the @ghc@ package, but which can be loaded on many compiler versions."
         ,"homepage: https://github.com/digital-asset/ghc-lib"
         ,"bug-reports: https://github.com/digital-asset/ghc-lib/issues"
+        ,"exposed: False" -- automatically hide `ghc-lib` (thanks Ed Kmett!)
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++
         indent dataFiles ++


### PR DESCRIPTION
This PR "auto-hides" `ghc-lib`.