### PR TITLE
Copyright headers for ghc-lib files

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -1,3 +1,7 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+
 -- CI script, invoked by both Travis and Appveyor
 
 import Control.Monad

--- a/CI.hs
+++ b/CI.hs
@@ -1,6 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
-
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 -- CI script, invoked by both Travis and Appveyor
 

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,2 @@
+Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,2 +1,2 @@
-Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
-SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -1,3 +1,6 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -1,5 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}

--- a/examples/mini-compile/test/MiniCompileTest.hs
+++ b/examples/mini-compile/test/MiniCompileTest.hs
@@ -1,5 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 -- Based on https://github.com/ghc/ghc/blob/23f6f31dd66d7c370cb8beec3f1d96a0cb577393/libraries/ghc-prim/GHC/Types.hs
 

--- a/examples/mini-compile/test/MiniCompileTest.hs
+++ b/examples/mini-compile/test/MiniCompileTest.hs
@@ -1,3 +1,6 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
 -- Based on https://github.com/ghc/ghc/blob/23f6f31dd66d7c370cb8beec3f1d96a0cb577393/libraries/ghc-prim/GHC/Types.hs
 
 {-# LANGUAGE NoImplicitPrelude #-}

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -1,3 +1,6 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -1,5 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}

--- a/examples/mini-hlint/test/MiniHlintTest.hs
+++ b/examples/mini-hlint/test/MiniHlintTest.hs
@@ -1,3 +1,6 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
 module MiniHlintTest where
 
 f :: Bool -> Int

--- a/examples/mini-hlint/test/MiniHlintTest.hs
+++ b/examples/mini-hlint/test/MiniHlintTest.hs
@@ -1,5 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 module MiniHlintTest where
 

--- a/ghc-lib-gen/Setup.hs
+++ b/ghc-lib-gen/Setup.hs
@@ -1,5 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 import Distribution.Simple
 main = defaultMain

--- a/ghc-lib-gen/Setup.hs
+++ b/ghc-lib-gen/Setup.hs
@@ -1,2 +1,5 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
 import Distribution.Simple
 main = defaultMain

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -1,6 +1,5 @@
--- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
--- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
-
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 -- | Generate a ghc-lib.cabal package given a GHC directory
 module Main(main) where

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -1,3 +1,7 @@
+-- Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
+
+
 -- | Generate a ghc-lib.cabal package given a GHC directory
 module Main(main) where
 


### PR DESCRIPTION
Add dual-licensed copyright headers to ghc-lib hs source files

```
Copyright 2019 Digital Asset (Switzerland) GmbH and/or its affiliates. All Rights Reserved.
SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
```