### PR TITLE
Get errors

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -56,4 +56,5 @@ main = do
     cmd "stack build --no-terminal --interleaved-output"
     cmd "stack exec --no-terminal -- ghc-lib --version"
     cmd "stack exec --no-terminal -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"
+    cmd "stack exec --no-terminal -- mini-hlint examples/mini-hlint/test/MiniHlintTest_error_handling.hs"
     cmd "stack exec --no-terminal -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -101,6 +101,5 @@ main = do
         POk _ m -> analyzeModule flags m
         PFailed s ->
           mapM_ putStrLn $
-          fmap (showSDoc flags) $
-          pprErrMsgBagWithLoc (snd $ getMessages s flags)
+          showSDoc flags <$> pprErrMsgBagWithLoc (snd $ getMessages s flags)
     _ -> fail "Exactly one file argument required"

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -2,7 +2,6 @@
 -- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 {-# LANGUAGE PackageImports #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
 
 module Main (main) where

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -2,6 +2,7 @@
 -- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
 
 {-# LANGUAGE PackageImports #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-missing-fields #-}
 
 module Main (main) where
@@ -99,7 +100,8 @@ main = do
       let flags = defaultDynFlags fakeSettings fakeLlvmConfig
       case parse file flags s of
         POk _ m -> analyzeModule flags m
-        PFailed _ ->
-          -- putStrLn $ showSDoc flags $ pprLocErrMsg $ mkPlainErrMsg flags loc err
-          putStrLn "Fix me" -- to do; call `getErrorMessages` to replace the old code above
+        PFailed s ->
+          mapM_ putStrLn $
+          fmap (showSDoc flags) $
+          pprErrMsgBagWithLoc (snd $ getMessages s flags)
     _ -> fail "Exactly one file argument required"

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -100,7 +100,7 @@ main = do
       case parse file flags s of
         POk _ m -> analyzeModule flags m
         PFailed s -> sequence_
-          [ putStrLn (showSDoc flags msg)
-          | msg <- pprErrMsgBagWithLoc (snd $ getMessages s flags)
+          [ putStrLn $ showSDoc flags msg
+          | msg <- pprErrMsgBagWithLoc $ snd $ getMessages s flags
           ]
     _ -> fail "Exactly one file argument required"

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -99,7 +99,9 @@ main = do
       let flags = defaultDynFlags fakeSettings fakeLlvmConfig
       case parse file flags s of
         POk _ m -> analyzeModule flags m
-        PFailed s ->
-          mapM_ putStrLn $
-          showSDoc flags <$> pprErrMsgBagWithLoc (snd $ getMessages s flags)
+        PFailed s -> sequence_
+          [ putStrLn msg
+          | msg <- showSDoc flags <$>
+                   pprErrMsgBagWithLoc (snd $ getMessages s flags)
+          ]
     _ -> fail "Exactly one file argument required"

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -100,8 +100,7 @@ main = do
       case parse file flags s of
         POk _ m -> analyzeModule flags m
         PFailed s -> sequence_
-          [ putStrLn msg
-          | msg <- showSDoc flags <$>
-                   pprErrMsgBagWithLoc (snd $ getMessages s flags)
+          [ putStrLn (showSDoc flags msg)
+          | msg <- pprErrMsgBagWithLoc (snd $ getMessages s flags)
           ]
     _ -> fail "Exactly one file argument required"

--- a/examples/mini-hlint/test/MiniHlintTest_error_handling.hs
+++ b/examples/mini-hlint/test/MiniHlintTest_error_handling.hs
@@ -1,0 +1,11 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+-- SPDX-License-Identifier: (Apache-2.0 OR BSD-3-Clause)
+
+module MiniHlintTest_error_handling where
+
+f :: a -> b
+
+-- test/MiniHlintTest_error_handling.hs:7:1: error:
+--    parse error on input `{'
+
+{

--- a/examples/mini-hlint/test/MiniHlintTest_error_handling.hs
+++ b/examples/mini-hlint/test/MiniHlintTest_error_handling.hs
@@ -5,7 +5,7 @@ module MiniHlintTest_error_handling where
 
 f :: a -> b
 
--- test/MiniHlintTest_error_handling.hs:7:1: error:
+-- test/MiniHlintTest_error_handling.hs:11:1: error:
 --    parse error on input `{'
 
 {


### PR DESCRIPTION
In this PR, `mini-hlint`'s error handling code is adapted to upstream changes to `data ParseResult`. 