### PR TITLE
Ubuntu xenial

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2,9 +2,59 @@
 # https://github.com/ndmitchell/hlint
 ##########################
 
-# Triggered by examples/mini-compile/test/MiniCompileTest.hs
-# Can't be fixed since haskell-src-exts can't parse the file
-- ignore: {name: "Parse error"}
+# This file contains a template configuration file, which is typically
+# placed as .hlint.yaml in the root of your project
 
-# A sample that deliberately has lots of HLint style errors
-- ignore: {within: "MiniHlintTest"}
+
+# Specify additional command line arguments
+#
+# - arguments: [--color, --cpp-simple, -XQuasiQuotes]
+
+
+# Control which extensions/flags/modules/functions can be used
+#
+# - extensions:
+#   - default: false # all extension are banned by default
+#   - name: [PatternGuards, ViewPatterns] # only these listed extensions can be used
+#   - {name: CPP, within: CrossPlatform} # CPP can only be used in a given module
+#
+# - flags:
+#   - {name: -w, within: []} # -w is allowed nowhere
+#
+# - modules:
+#   - {name: [Data.Set, Data.HashSet], as: Set} # if you import Data.Set qualified, it must be as 'Set'
+#   - {name: Control.Arrow, within: []} # Certain modules are banned entirely
+#
+# - functions:
+#   - {name: unsafePerformIO, within: []} # unsafePerformIO can only appear in no modules
+
+
+# Add custom hints for this project
+#
+# Will suggest replacing "wibbleMany [myvar]" with "wibbleOne myvar"
+# - error: {lhs: "wibbleMany [x]", rhs: wibbleOne x}
+
+
+# Turn on hints that are off by default
+#
+# Ban "module X(module X) where", to require a real export list
+# - warn: {name: Use explicit module export list}
+#
+# Replace a $ b $ c with a . b $ c
+# - group: {name: dollar, enabled: true}
+#
+# Generalise map to fmap, ++ to <>
+# - group: {name: generalise, enabled: true}
+
+
+# Ignore some builtin hints
+# - ignore: {name: Use let}
+# - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
+
+
+# Define some custom infix operators
+# - fixity: infixr 3 ~^#^~
+
+
+# To generate a suitable file for HLint do:
+# $ hlint --default > .hlint.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ os:
 - osx
 
 script:
-- curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s
+- curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s .
 - curl -sSL https://get.haskellstack.org/ | sh
 - stack setup > /dev/null
 - stack --no-terminal build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
+dist: xenial
+
 sudo: required
 
 os:
 - linux
 - osx
 
-services:
-- docker
-
-# [Why we git clone on linux here]
-# At this time, `git clone https://gitlab.haskell.org/ghc/ghc.git`
-# from within `CI.hs` does not work on on linux. This appears to be a
-# known Travis/ubuntu SSL verification issue. We've tried many less
-# drastic workarounds. This grand hack is the only way we've found so
-# far that can be made to work.
-before_install:
-- |
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      docker pull alpine/git
-      docker run -ti --rm -v ${HOME}:/root -v $(pwd):/git alpine/git clone https://gitlab.haskell.org/ghc/ghc.git /git/ghc --recursive
-    fi
-
 script:
+- curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s
 - curl -sSL https://get.haskellstack.org/ | sh
 - stack setup > /dev/null
 - stack --no-terminal build

--- a/CI.hs
+++ b/CI.hs
@@ -21,16 +21,7 @@ main = do
             hFlush stdout
     when isWindows $
         cmd "stack exec -- pacman -S autoconf automake-wrapper make patch python tar --noconfirm"
-    when (isWindows || isMac) $
-        cmd "git clone https://gitlab.haskell.org/ghc/ghc.git --recursive"
-             -- ^ The `git clone` is handled in .travis.yml for linux
-             -- (workaround travis bug).
-
-    -- See note [Why we git clone on linux here] in .travis.yml.
-    when (not (isWindows || isMac)) $ do
-      cmd "sudo chown -R travis:travis ghc"
-      -- ^ Because 'root' owns ghc and we can't read/write.
-
+    cmd "git clone https://gitlab.haskell.org/ghc/ghc.git --recursive"
     -- This is not essential, but make the cache work between Hadrian
     -- and ghc-lib in order to build hadrian quicker.
     appendFile "ghc/hadrian/stack.yaml" $ unlines ["ghc-options:","  \"$everything\": -O0 -j"]


### PR DESCRIPTION
Upgrading to `xenial` allows us to avoid having to spin up a container outside of `CI.hs` to `git clone https://gitlab.haskell.org/ghc/ghc.git`. Additionally, added a default `.hlint.yaml` file to the root directory and restored invoking `hlint` from the `script` directive of `.travis.yml`.