### PR TITLE
mini-hlint to depend on ghc-lib-parser only

### DIFF
--- a/examples/mini-hlint/mini-hlint.cabal
+++ b/examples/mini-hlint/mini-hlint.cabal
@@ -13,6 +13,6 @@ executable mini-hlint
   main-is:             Main.hs
   build-depends:       base >=4.11
                      , extra
-                     , ghc-lib
+                     , ghc-lib-parser
   default-language:    Haskell2010
   hs-source-dirs:      src

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -6,7 +6,7 @@
 
 module Main (main) where
 
-import "ghc-lib" GHC
+import "ghc-lib-parser" HsSyn
 import "ghc-lib-parser" Config
 import "ghc-lib-parser" DynFlags
 import "ghc-lib-parser" Platform


### PR DESCRIPTION
This PR changes `mini-hlint` such that it has no build dependency on ghc-lib, just ghc-lib-parser.