### PR TITLE
More refinement of mini-hlint error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ cat << EOF >> stack.yaml
 EOF
 stack build mini-hlint
 stack build mini-compile
+
+# Execute the examples
+stack exec mini-hlint -- examples/mini-hlint/test/MiniHlintTest.hs
+stack exec mini-hlint -- examples/mini-hlint/test/MiniHlintTest_fatal_error.hs
+stack exec mini-hlint -- examples/mini-hlint/test/MiniHlintTest_non_fatal_error.hs
+stack exec mini-compile -- examples/mini-compile/test/MiniCompileTest.hs
 ```
 
 ## Releasing `ghc-lib` (notes for maintainers)

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -103,13 +103,12 @@ main = do
         POk s m -> do
           let (warns, errs) = getMessages s flags
           report flags warns
-          if not (null errs)
-            then report flags errs
-            else analyzeModule flags m
+          report flags errs
+          when (null errs) $ analyzeModule flags m
     _ -> fail "Exactly one file argument required"
   where
-    report flags errs =
+    report flags msgs =
       sequence_
         [ putStrLn $ showSDoc flags msg
-        | msg <- pprErrMsgBagWithLoc errs
+        | msg <- pprErrMsgBagWithLoc msgs
         ]


### PR DESCRIPTION
Eliminate the conditional; replace with a when. You were right. Much simpler. Also in this PR, stack commands in the README for executing the examples. 