### PR TITLE
Mangle C symbols to avoid collisions with the "ghc" lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
+dist-newstyle/
+.ghc.environment.*
 ghc/
 ghc-master/
 .vscode/


### PR DESCRIPTION
This PR prefixes the exported C symbols in ghc-lib-parser with
ghc_lib_parser_ to describe symbol collisions as described in #64. I
haven’t been able to reproduce the issue in #64 but I am reasonably
confident this helps.