### PR TITLE
Try to recover the mini-compile example

### DIFF
--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -78,7 +78,7 @@ fakeSettings = Settings
   , sProgramName="ghc"
   , sOpt_P_fingerprint=fingerprint0
   , sTmpDir="."
-  , sIntegerLibraryType = "integer-simple"
+  , sIntegerLibraryType=IntegerSimple
   }
   where
     platform =

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -78,6 +78,7 @@ fakeSettings = Settings
   , sProgramName="ghc"
   , sOpt_P_fingerprint=fingerprint0
   , sTmpDir="."
+  , sIntegerLibraryType = "integer-simple"
   }
   where
     platform =


### PR DESCRIPTION
Provide a definition for record field `sIntegerLibraryType`.