### PR TITLE
Add new module LinkerTypes to ghc-lib-parser

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -218,6 +218,7 @@ parserModules =
   , "Language.Haskell.TH.Syntax"
   , "Lexeme"
   , "Lexer"
+  , "LinkerTypes"
   , "ListSetOps"
   , "Literal"
   , "Maybes"


### PR DESCRIPTION
There's a new module `LinkerTypes` to be included in `ghc-lib-parser`.