### PR TITLE
New ghc-lib-parser source file 'PlainPanic.hs'

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -243,6 +243,7 @@ parserModules =
   , "PatSyn"
   , "PipelineMonad"
   , "PlaceHolder"
+  , "PlainPanic"
   , "Platform"
   , "PlatformConstants"
   , "Plugins"


### PR DESCRIPTION
This PR adds a newly added ghc source file to `ghc-lib-parser`.