### PR TITLE
Note in release procedure to fix ghc-lib-parser in build-depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ cabal run -- ghc --ghc-lib
 cd ghc
 ```
 
-Then edit `ghc-lib.cabal` to fix the version number (e.g. 0.20190204)
-before executing:
+Then edit `ghc-lib.cabal` to fix the version number (e.g. 0.20190204) and constrain the `ghc-lib-parser` version in the `build-depends` section before executing:
 
 ```bash
 cabal sdist


### PR DESCRIPTION
Note in the release procedure of `ghc-lib` that the `ghc-lib-parser` entry in the `build-depends` section should be constrained to the new release version