### PR TITLE
Adapt to upstream changes

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -164,6 +164,7 @@ parserModules =
   , "FiniteMap"
   , "ForeignCall"
   , "GhcNameVersion"
+  , "GHC.BaseDir"
   , "GHC.Exts.Heap"
   , "GHC.Exts.Heap.ClosureTypes"
   , "GHC.Exts.Heap.Closures"


### PR DESCRIPTION
This PR adds `GHC.BaseDir` to `ghc-lib-parser` introduced in `387050d0e26a9e6466b31c9d8e4e4f6273c64c9e`.