### PR TITLE
Stack upgrade highlights some deficienies in CI.hs

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -29,15 +29,19 @@ main = do
     renameDirectory (dropExtensions tarball) "ghc-lib-parser"
     removeFile tarball
     removeFile "ghc/ghc-lib-parser.cabal"
+    cmd "git checkout stack.yaml"
 
     -- Make and extract an sdist of ghc-lib.
     cmd "cd ghc && git checkout ."
     appendFile "ghc/hadrian/stack.yaml" $ unlines ["ghc-options:","  \"$everything\": -O0 -j"]
     cmd "stack exec -- ghc-lib-gen ghc --ghc-lib"
+    stackYaml <- readFile' "stack.yaml"
+    writeFile "stack.yaml" $ stackYaml ++ unlines ["- ghc"]
     tarball <- sDistCreateExtract
     renameDirectory (dropExtensions tarball) "ghc-lib"
     removeFile tarball
     removeFile "ghc/ghc-lib.cabal"
+    cmd "git checkout stack.yaml"
 
     -- Test the new projects.
     writeFile "stack.yaml" $


### PR DESCRIPTION
The newest version of `stack` is a little stricter than it was highlighting some abuses we were making in `CI.hs`. This sorts it out.