### PR TITLE
Use a $ to reduce syntactic noise

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -70,13 +70,12 @@ ghcLibParserHsSrcDirs lib =
   -- so that in 'calcParserModules', longer substituions are performed
   -- before shorter ones (and bad things will happen if that were
   -- not the case).
-  sortBy (flip (comparing length))
-    ([ "ghc-lib/stage0/compiler/build"
-     , "ghc-lib/stage1/compiler/build"
-     , "ghc-lib/stage0/libraries/ghci/build"
-     , "ghc-lib/stage0/libraries/ghc-heap/build"
-     ] ++ map takeDirectory cabalFileLibraries ++
-      askFiles lib "hs-source-dirs:")
+  sortBy (flip (comparing length)) $
+    [ "ghc-lib/stage0/compiler/build"
+    , "ghc-lib/stage1/compiler/build"
+    , "ghc-lib/stage0/libraries/ghci/build"
+    , "ghc-lib/stage0/libraries/ghc-heap/build"]
+    ++ map takeDirectory cabalFileLibraries ++ askFiles lib "hs-source-dirs:"
 
 -- | The "hs-source-dirs" for 'ghc-lib-parser'. Approximation. Needs
 -- adjusting.

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -74,10 +74,10 @@ ghcLibParserHsSrcDirs lib =
     [ "ghc-lib/stage0/compiler/build"
     , "ghc-lib/stage1/compiler/build"
     , "ghc-lib/stage0/libraries/ghci/build"
-    , "ghc-lib/stage0/libraries/ghc-heap/build"]
+    , "ghc-lib/stage0/libraries/ghc-heap/build" ]
     ++ map takeDirectory cabalFileLibraries ++ askFiles lib "hs-source-dirs:"
 
--- | The "hs-source-dirs" for 'ghc-lib-parser'. Approximation. Needs
+-- | The "hs-source-dirs" for 'ghc-lib'. Approximation. Needs
 -- adjusting.
 ghcLibHsSrcDirs :: [Cabal] -> [FilePath]
 ghcLibHsSrcDirs = ghcLibParserHsSrcDirs


### PR DESCRIPTION
Acting on @neil-da 's suggestion for a $ to reduce parentheses.