### PR TITLE
mini-hlint : add code to get annotations

### DIFF
--- a/examples/mini-hlint/mini-hlint.cabal
+++ b/examples/mini-hlint/mini-hlint.cabal
@@ -14,5 +14,6 @@ executable mini-hlint
   build-depends:       base >=4.11
                      , extra
                      , ghc-lib-parser
+                     , containers
   default-language:    Haskell2010
   hs-source-dirs:      src

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -24,11 +24,13 @@ import "ghc-lib-parser" ToolSettings
 import "ghc-lib-parser" Panic
 import "ghc-lib-parser" HscTypes
 import "ghc-lib-parser" HeaderInfo
+import "ghc-lib-parser" ApiAnnotation
 
 import Control.Monad
 import Control.Monad.Extra
 import System.Environment
 import System.IO.Extra
+import qualified Data.Map as Map
 
 fakeSettings :: Settings
 fakeSettings = Settings
@@ -109,8 +111,8 @@ analyzeExpr flags (L loc expr) =
         analyzeExpr flags z
     _ -> return ()
 
-analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> IO ()
-analyzeModule flags modu = sequence_
+analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> ApiAnns -> IO ()
+analyzeModule flags modu _anns = sequence_
   [ analyzeExpr flags expr
   | L _ HsModule {hsmodDecls=decls} <- [modu]
   , L _ (ValD _ FunBind{fun_matches=MG {mg_alts=(L _ matches)}}) <- decls
@@ -128,14 +130,14 @@ main = do
         parsePragmasIntoDynFlags
           (defaultDynFlags fakeSettings fakeLlvmConfig) file s
       whenJust flags $ \flags ->
-         case parse file flags s of
+         case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
             PFailed s ->
               report flags $ snd (getMessages s flags)
             POk s m -> do
               let (wrns, errs) = getMessages s flags
               report flags wrns
               report flags errs
-              when (null errs) $ analyzeModule flags m
+              when (null errs) $ analyzeModule flags m (harvestAnns s)
     _ -> fail "Exactly one file argument required"
   where
     report flags msgs =
@@ -143,3 +145,7 @@ main = do
         [ putStrLn $ showSDoc flags msg
         | msg <- pprErrMsgBagWithLoc msgs
         ]
+    harvestAnns pst =
+      ( Map.fromListWith (++) $ annotations pst
+      , Map.fromList ((noSrcSpan, comment_q pst) : annotations_comments pst)
+      )


### PR DESCRIPTION
This PR extends the `mini-hlint` example showing how to harvest annotations.