### PR TITLE
Advance to ghc at  de3935a6ccc26ec063e13d2739dd098c7616fde2

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -18,7 +18,7 @@ main = do
         cmd "stack exec -- pacman -S autoconf automake-wrapper make patch python tar --noconfirm"
 
     cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
-    cmd "cd ghc && git checkout a25f6f55eaca0d3ec36afb574d5fa9326ea09d55"
+    cmd "cd ghc && git checkout de3935a6ccc26ec063e13d2739dd098c7616fde2" -- 07/12/2019
     cmd "cd ghc && git submodule update --init --recursive"
 
     appendFile "ghc/hadrian/stack.yaml" $ unlines ["ghc-options:","  \"$everything\": -O0 -j"]

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -100,6 +100,7 @@ fakeSettings = Settings
         platformWordSize=8
       , platformOS=OSUnknown
       , platformUnregisterised=True
+      , platformArch=ArchUnknown
       }
     platformConstants =
        PlatformConstants {

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -63,6 +63,7 @@ ghcLibParserHsSrcDirs lib =
         , "ghc-lib/stage1/compiler/build"
         , "ghc-lib/stage0/libraries/ghci/build"
         , "ghc-lib/stage0/libraries/ghc-heap/build"
+        , "ghc-lib/stage0/libraries/ghc-boot/build"
         ]
         ++ map takeDirectory cabalFileLibraries
         ++ askFiles lib "hs-source-dirs:"
@@ -122,7 +123,7 @@ dataFiles =
 -- list are all created by Hadrian.
 extraFiles :: [FilePath]
 extraFiles =
-    -- source files
+    -- See ghc/hadrian/src/Rules/Generate.hs
     ["ghc-lib/generated/ghcautoconf.h"
     ,"ghc-lib/generated/ghcplatform.h"
     ,"ghc-lib/generated/ghcversion.h"
@@ -152,6 +153,7 @@ extraFiles =
     ,"ghc-lib/stage1/compiler/build/Config.hs"
     ,"ghc-lib/stage0/compiler/build/Parser.hs"
     ,"ghc-lib/stage0/compiler/build/Lexer.hs"
+    ,"ghc-lib/stage0/libraries/ghc-boot/build/GHC/Version.hs"
     ]
 
 -- | Calculate via `ghc -M` the list of modules that are required for
@@ -377,9 +379,9 @@ generateGhcLibCabal = do
         ,"data-files:"] ++
         indent dataFiles ++
         ["extra-source-files:"] ++
-        -- Remove Config.hs, Parser.hs and Lexer.hs from the list of
-        -- extra source files here.
-        indent (reverse (drop 3 $ reverse extraFiles)) ++
+        -- Remove Config.hs, Version.hs, Parser.hs and Lexer.hs from
+        -- the list of extra source files here.
+        indent (reverse (drop 4 $ reverse extraFiles)) ++
         ["    includes/*.h"
         ,"    includes/CodeGen.Platform.hs"
         ,"    includes/rts/*.h"


### PR DESCRIPTION
Adapt `ghc-lib-gen` to latest on HEAD.

Small change for a now required record field in the settings of  `mini-compile` but mostly about adapting `ghc-lib-gen` to https://gitlab.haskell.org/ghc/ghc/commit/24782b89907ab36fb5aef3a17584f4c10f1e2690 whereby we need to tell hadrian to generate `GHC/Version.hs` and add its containing directory to the `ghcLibParserHsSrcDirs`.