### PR TITLE
Simplify mini-hlint by using listify

### DIFF
--- a/examples/mini-hlint/mini-hlint.cabal
+++ b/examples/mini-hlint/mini-hlint.cabal
@@ -15,5 +15,6 @@ executable mini-hlint
                      , extra
                      , ghc-lib-parser
                      , containers
+                     , syb
   default-language:    Haskell2010
   hs-source-dirs:      src


### PR DESCRIPTION
Eliminate explicit tree traversal by using of `listify` from syb.