### PR TITLE
ghc-lib-gen eliminate maybe from command line arg

### DIFF
--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -10,6 +10,7 @@ module GhclibgenOpts(
 ) where
 
 import Options.Applicative
+import Data.Maybe
 import Data.Version (showVersion)
 import Data.Semigroup ((<>))
 import Paths_ghc_lib_gen (version)
@@ -20,7 +21,7 @@ data GhclibgenTarget = GhclibParser | Ghclib
 -- | The type of ghc-lib-gen options.
 data GhclibgenOpts = GhclibgenOpts {
     ghclibgenOpts_root :: !FilePath -- ^ Path to a GHC git repository.
-  , ghclibgenOpts_target :: !(Maybe GhclibgenTarget) -- ^ What target?
+  , ghclibgenOpts_target :: !GhclibgenTarget -- ^ What target?
  }
 
 -- | A parser of the "--ghc-lib" target.
@@ -46,11 +47,11 @@ ghclibgenVersion =
 
 -- | A parser of a ghc-lib-gen target: `target := | "--ghc-lib-parser"
 -- | "--ghc-lib" | /* nothing */`.
-ghclibgenTarget :: Parser (Maybe GhclibgenTarget)
-ghclibgenTarget = optional (ghclibParser <|> ghclib)
+ghclibgenTarget :: Parser GhclibgenTarget
+ghclibgenTarget = fmap (fromMaybe Ghclib) $ optional (ghclibParser <|> ghclib)
 
 -- | A parser of ghc-lib-gen options: `opts := STRING target`.
 ghclibgenOpts :: Parser GhclibgenOpts
 ghclibgenOpts = GhclibgenOpts
   <$> argument str (metavar "GHC_ROOT")
-  <*> optional (ghclibParser <|> ghclib)
+  <*> ghclibgenTarget

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -24,12 +24,12 @@ ghclibgen :: GhclibgenOpts -> IO ()
 ghclibgen (GhclibgenOpts root target) =
   withCurrentDirectory root $
     case target of
-      Just GhclibParser -> do
+      GhclibParser -> do
         init
         mangleCSymbols
         applyPatchStage
         generateGhcLibParserCabal
-      _ -> do
+      Ghclib -> do
         init
         generateGhcLibCabal
   where


### PR DESCRIPTION
Use `fmap` to get rid of the `Maybe` in the parser for the ghc-lib-gen target.