### PR TITLE
New example : strip locations; dump-parse tree

### DIFF
--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -1,0 +1,123 @@
+-- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its
+-- affiliates. All rights reserved.  SPDX-License-Identifier:
+-- (Apache-2.0 OR BSD-3-Clause)
+
+{-# LANGUAGE PackageImports #-}
+{-# OPTIONS_GHC -Wno-missing-fields #-}
+
+module Main (main) where
+
+import "ghc-lib-parser" HsSyn
+import "ghc-lib-parser" Config
+import "ghc-lib-parser" DynFlags
+import "ghc-lib-parser" GHC.Platform
+import "ghc-lib-parser" StringBuffer
+import "ghc-lib-parser" Fingerprint
+import "ghc-lib-parser" Lexer
+import "ghc-lib-parser" RdrName
+import "ghc-lib-parser" ErrUtils
+import qualified "ghc-lib-parser" Parser
+import "ghc-lib-parser" FastString
+import "ghc-lib-parser" Outputable
+import "ghc-lib-parser" SrcLoc
+import "ghc-lib-parser" ToolSettings
+import "ghc-lib-parser" Panic
+import "ghc-lib-parser" HscTypes
+import "ghc-lib-parser" HeaderInfo
+import "ghc-lib-parser" ApiAnnotation
+
+import "ghc-lib" HsDumpAst
+
+import Control.Monad
+import Control.Monad.Extra
+import System.Environment
+import System.IO.Extra
+import qualified Data.Map as Map
+import Data.Generics.Uniplate.Operations
+import Data.Generics.Uniplate.Data
+
+fakeSettings :: Settings
+fakeSettings = Settings
+  { sGhcNameVersion=ghcNameVersion
+  , sFileSettings=fileSettings
+  , sTargetPlatform=platform
+  , sPlatformMisc=platformMisc
+  , sPlatformConstants=platformConstants
+  , sToolSettings=toolSettings
+  }
+  where
+    toolSettings = ToolSettings {
+      toolSettings_opt_P_fingerprint=fingerprint0
+      }
+    fileSettings = FileSettings {}
+    platformMisc = PlatformMisc {}
+    ghcNameVersion =
+      GhcNameVersion{ghcNameVersion_programName="ghc"
+                    ,ghcNameVersion_projectVersion=cProjectVersion
+                    }
+    platform =
+      Platform{platformWordSize=8
+              , platformOS=OSUnknown
+              , platformUnregisterised=True}
+    platformConstants =
+      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
+
+fakeLlvmConfig :: (LlvmTargets, LlvmPasses)
+fakeLlvmConfig = ([], [])
+
+parse :: String -> DynFlags -> String -> ParseResult (Located (HsModule GhcPs))
+parse filename flags str =
+  unP Parser.parseModule parseState
+  where
+    location = mkRealSrcLoc (mkFastString filename) 1 1
+    buffer = stringToStringBuffer str
+    parseState = mkPState flags buffer location
+
+parsePragmasIntoDynFlags :: DynFlags -> FilePath -> String -> IO (Maybe DynFlags)
+parsePragmasIntoDynFlags flags filepath str =
+  catchErrors $ do
+    let opts = getOptions flags (stringToStringBuffer str) filepath
+    (flags, _, _) <- parseDynamicFilePragma flags opts
+    return $ Just flags
+  where
+    catchErrors :: IO (Maybe DynFlags) -> IO (Maybe DynFlags)
+    catchErrors act = handleGhcException reportErr
+                        (handleSourceError reportErr act)
+    reportErr e = do putStrLn $ "error : " ++ show e; return Nothing
+
+dumpParseTree :: DynFlags -> Located (HsModule GhcPs) -> IO ()
+dumpParseTree flags m =
+  dumpSDoc flags alwaysQualify Opt_D_dump_parsed_ast "" $ showAstData NoBlankSrcSpan m
+
+stripLocs :: Located (HsModule GhcPs) -> Located (HsModule GhcPs)
+stripLocs = transformBi $ const noSrcSpan
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    [file] -> do
+      s <- readFile' file
+      flags <-
+        parsePragmasIntoDynFlags
+          (defaultDynFlags fakeSettings fakeLlvmConfig) file s
+      whenJust flags $ \flags ->
+         case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
+            PFailed s ->
+              report flags $ snd (getMessages s flags)
+            POk s m -> do
+              let (wrns, errs) = getMessages s flags
+              report flags wrns
+              report flags errs
+              when (null errs) $ dumpParseTree flags (stripLocs m)
+    _ -> fail "Exactly one file argument required"
+  where
+    report flags msgs =
+      sequence_
+        [ putStrLn $ showSDoc flags msg
+        | msg <- pprErrMsgBagWithLoc msgs
+        ]
+    harvestAnns pst =
+      ( Map.fromListWith (++) $ annotations pst
+      , Map.fromList ((noSrcSpan, comment_q pst) : annotations_comments pst)
+      )

--- a/examples/strip-locs/strip-locs.cabal
+++ b/examples/strip-locs/strip-locs.cabal
@@ -1,0 +1,21 @@
+name:                strip-locs
+version:             0.1.0.0
+license:             BSD3
+x-license:           BSD3-Clause OR Apache-2.0
+license-file:        ../../LICENSE
+author:              Shayne Fletcher (shayne.fletcher@digitalasset.com)
+maintainer:          Shayne Fletcher (shayne.fletcher@digitalasset.com)
+copyright:           Digital Asset 2018-2019
+build-type:          Simple
+cabal-version:       >=1.10
+
+executable strip-locs
+  main-is:             Main.hs
+  build-depends:       base >=4.11
+                     , extra
+                     , ghc-lib-parser
+                     , ghc-lib
+                     , containers
+                     , uniplate
+  default-language:    Haskell2010
+  hs-source-dirs:      src

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -9,6 +9,7 @@ module GhclibgenOpts(
   , ghclibgenOpts
 ) where
 
+import Control.Applicative
 import Options.Applicative
 import Data.Maybe
 import Data.Version (showVersion)
@@ -48,7 +49,8 @@ ghclibgenVersion =
 -- | A parser of a ghc-lib-gen target: `target := | "--ghc-lib-parser"
 -- | "--ghc-lib" | /* nothing */`.
 ghclibgenTarget :: Parser GhclibgenTarget
-ghclibgenTarget = fmap (fromMaybe Ghclib) $ optional (ghclibParser <|> ghclib)
+ghclibgenTarget =
+  fromMaybe Ghclib Control.Applicative.<$> optional (ghclibParser <|> ghclib)
 
 -- | A parser of ghc-lib-gen options: `opts := STRING target`.
 ghclibgenOpts :: Parser GhclibgenOpts


### PR DESCRIPTION
Example with a function to get output like `-ddump-parsed-ast` and use of uniplate to strip source locations from a parse tree. Also removes a lint from `ghc-lib-gen` options parsing.