### PR TITLE
Do not use RTS headers; prefer the compiler ones

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -35,6 +35,7 @@ ghclibgen (GhclibgenOpts root target) =
   where
     init :: IO ()
     init = do
+        applyPatchRtsIncludePaths
         applyPatchHeapClosures
         applyPatchDisableCompileTimeOptimizations
         generatePrerequisites


### PR DESCRIPTION
(1) Reduce the `includes` directory in the two packages to the following files:
```
ghcconfig.h
MachDeps.h
CodeGen.Platform.hs
```
(2) Patch
 - `compiler/cmm/SMRep.hs`
   Before:
   ```
   #include "../includes/rts/storage/ClosureTypes.h"
   ```
- `compiler/codeGen/StgCmmLayout.hs`
   After:
   ```
   #include "rts/storage/ClosureTypes.h"
   ```
(3) Add `includes` to the cabal `include-dirs` in both packages.
