### PR TITLE
Disable CI on da-ghc-8.8.1 again

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,7 +8,6 @@ trigger:
   branches:
     include:
     - master
-    - da-ghc-8.8.1
 
 # Enable PR triggers that target the master branch
 pr:
@@ -16,7 +15,6 @@ pr:
   branches:
     include:
     - master
-    - da-ghc-8.8.1
 
 strategy:
   matrix:


### PR DESCRIPTION
Now that we have merged da-ghc-8.8.1 into master there is little
reason to keep it around.