### PR TITLE
Sync to 7915afc6bb9539a4534db99aeb6616a6d145918a

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -44,7 +44,8 @@ data GhcFlavor = Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current =    "7208160d2caae125479e8dd39a263620ea7e0ffe" -- 09/16/2019
+current =    "7915afc6bb9539a4534db99aeb6616a6d145918a" -- 09/16/2019
+          -- "7208160d2caae125479e8dd39a263620ea7e0ffe" -- 09/16/2019
           -- "270fbe8512f04b6107755fa22bdec62205c0a567" -- 09/09/2019
           -- "b55ee979d32df938eee9c4c02c189f8be267e8a1" -- 09/06/2019
           -- "11679e5bec1994775072e8e60f24b4ce104af0a7" -- 09/03/2019
@@ -203,6 +204,11 @@ buildDists ghcFlavor resolver = do
               , "- examples/mini-hlint"
               , "- examples/mini-compile"
               , "- examples/strip-locs"
+              -- 'master' now requires transformers >= 5.6.2 which is
+              -- beyond the default for ghc-4.4. This hack works
+              -- around.
+              , ""
+              , "allow-newer: true"
               ] ++
       if ghcFlavor == DaGhc881
         then unlines ["flags: {mini-compile: {daml-unit-ids: true}}"]

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -33,12 +33,13 @@ import "ghc-lib-parser" ApiAnnotation
 #ifdef GHC_MASTER
 import "ghc-lib-parser" GHC.Platform
 import "ghc-lib-parser" ToolSettings
+import "ghc-lib-parser" HsDumpAst
 #else
 import "ghc-lib-parser" Bag
 import "ghc-lib-parser" Platform
+import "ghc-lib" HsDumpAst
 #endif
 
-import "ghc-lib" HsDumpAst
 
 import Control.Monad
 import Control.Monad.Extra


### PR DESCRIPTION
We need to consider this before landing it. The long and the short of it is that the referenced commit has drastically changed modularity in the GHC API such that to run the parser now requires 534 files whereas before that commit, it only needed 200 or so. 