### PR TITLE
Sync with upstream

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -44,7 +44,9 @@ data GhcFlavor = Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current =    "7208160d2caae125479e8dd39a263620ea7e0ffe" -- 09/16/2019
+current =    "1b7e1d31fee4176608e46d45ddc195e313eed978" -- 09/20/2019
+          -- "521739900fe993ff73ec0da2215bc7572a15826d" -- 09/19/2019
+          -- "7208160d2caae125479e8dd39a263620ea7e0ffe" -- 09/16/2019
           -- "270fbe8512f04b6107755fa22bdec62205c0a567" -- 09/09/2019
           -- "b55ee979d32df938eee9c4c02c189f8be267e8a1" -- 09/06/2019
           -- "11679e5bec1994775072e8e60f24b4ce104af0a7" -- 09/03/2019
@@ -204,9 +206,16 @@ buildDists ghcFlavor resolver = do
               , "- examples/mini-compile"
               , "- examples/strip-locs"
               ] ++
-      if ghcFlavor == DaGhc881
-        then unlines ["flags: {mini-compile: {daml-unit-ids: true}}"]
-        else ""
+      case ghcFlavor of
+        GhcMaster _ ->
+          -- Resolver 'lts-12.26' serves 'transformers-0.5.5.0' which
+          -- lacks 'Control.Monad.Trans.RWS.CPS'. The need for that
+          -- module came in around around 09/20/2019. Putting this here
+          -- keeps the CI ghc-8.4.4 builds going.
+          unlines ["extra-deps: [transformers-0.5.6.2]"]
+        DaGhc881 ->
+          unlines ["flags: {mini-compile: {daml-unit-ids: true}}"]
+        _ -> ""
 
     -- All invocations of GHC from here on are using our resolver.
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -13,7 +13,11 @@ module Main (main) where
 #  define GHC_MASTER
 #endif
 
+#ifdef GHC_MASTER
+import "ghc-lib-parser" GHC.Hs
+#else
 import "ghc-lib-parser" HsSyn
+#endif
 import "ghc-lib-parser" Config
 import "ghc-lib-parser" DynFlags
 import "ghc-lib-parser" StringBuffer

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -13,7 +13,11 @@ module Main (main) where
 #  define GHC_MASTER
 #endif
 
+#ifdef GHC_MASTER
+import "ghc-lib-parser" GHC.Hs
+#else
 import "ghc-lib-parser" HsSyn
+#endif
 import "ghc-lib-parser" Config
 import "ghc-lib-parser" DynFlags
 import "ghc-lib-parser" StringBuffer
@@ -38,7 +42,11 @@ import "ghc-lib-parser" Bag
 import "ghc-lib-parser" Platform
 #endif
 
+#ifdef GHC_MASTER
+import "ghc-lib" GHC.Hs.Dump
+#else
 import "ghc-lib" HsDumpAst
+#endif
 
 import Control.Monad
 import Control.Monad.Extra

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -280,13 +280,18 @@ calcParserModules ghcFlavor = do
 -- those identified as bottlenecks in the 2019 GSoC Hadrian speed
 -- project.
 applyPatchDisableCompileTimeOptimizations :: GhcFlavor -> IO ()
-applyPatchDisableCompileTimeOptimizations _ =
-    forM_ [ "compiler/main/DynFlags.hs"
-          , "compiler/hsSyn/HsInstances.hs" ] $
-    \file ->
-        writeFile file .
-        ("{-# OPTIONS_GHC -O0 #-}\n" ++)
-        =<< readFile' file
+applyPatchDisableCompileTimeOptimizations ghcFlavor =
+    let files =
+          ["compiler/main/DynFlags.hs"] ++
+          (case ghcFlavor of
+            GhcMaster -> [ "compiler/GHC/Hs.hs" ]
+            _ ->         [ "compiler/hsSyn/HsInstances.hs" ])
+    in
+      forM_ files $
+        \file ->
+          writeFile file .
+          ("{-# OPTIONS_GHC -O0 #-}\n" ++)
+          =<< readFile' file
 
 -- | Stub out a couple of definitions in the ghc-heap library that
 -- require CMM features, since Cabal doesn't work well with CMM files.


### PR DESCRIPTION
Sync to `1b7e1d31fee4176608e46d45ddc195e313eed978` (includes https://gitlab.haskell.org/ghc/ghc/commit/baf47661426e6f60c5fbfd2fb29cb446aa007576).