### PR TITLE
limit parallel jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ pr:
     - master
 
 strategy:
+  # Limit number of executors used so other pipelines can run too
+  maxParallel: 10
   matrix:
     # ghc-lib v8.8.1 (vanilla)
 


### PR DESCRIPTION
We currently have a total limit of 15 parallel executions on Azure (across all DA projects). The matrix as configured will start 18 jobs, meaning no other pipeline can run at all.

Adding a limit of 10 so other pipelines can still use 5.