### PR TITLE
Sync upstream

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -44,7 +44,8 @@ data GhcFlavor = Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current =    "8039b6257ce5288e9e38c2593ff2d5d6d316efd4" -- 10/05/2019
+current =    "241921a0c238a047326b0c0f599f1c24222ff66c" -- 10/05/2019
+          -- "8039b6257ce5288e9e38c2593ff2d5d6d316efd4" -- 10/05/2019
           -- "822481d5658280fa76f648c3d56dc6a456b8d3a3" -- 10/01/2019
           -- "6f9fa0be8d43a7c9618f6e27e3190dc08bf86bfa" -- 09/28/2019
           -- "68ddb43c44065d0d3a8a6893f7f8e87f15ee9c1e" -- 09/23/2019


### PR DESCRIPTION
Another upstream sweep `241921a0c238a047326b0c0f599f1c24222ff66c`. 