### PR TITLE
Sync upstream

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -44,7 +44,8 @@ data GhcFlavor = Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current =    "9402608ea5955c70fee51f8b892d418252846a9b" -- 10/08/2019
+current =    "d584e3f08cfee6e28b70bf53c573d86e44f326f8" -- 10/09/2019
+          -- "9402608ea5955c70fee51f8b892d418252846a9b" -- 10/08/2019
           -- "31a29a7a626ca0004c54bff4e087ea3894753410" -- 10/07/2019
           -- "241921a0c238a047326b0c0f599f1c24222ff66c" -- 10/05/2019
           -- "8039b6257ce5288e9e38c2593ff2d5d6d316efd4" -- 10/05/2019

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -383,7 +383,13 @@ mangleCSymbols _ = do
 -- by using getOrSetLibHSghc for the FastString table.
 applyPatchStage :: GhcFlavor -> IO ()
 applyPatchStage ghcFlavor =
-    forM_ [ "compiler/ghci/Linker.hs"
+  -- On master, `ghcplatform.h` sets `GHC_STAGE` to `1` and we no
+  -- longer are required to pass `-DGHC_STAGE=2` to `cpp-options` to
+  -- get a build (`MachDeps.h` does not hide its contents from stages
+  -- below 2 anymore). All usages of `getOrSetLibHSghc*` require
+  -- `GHC_STAGE >= 2` . Thus, it's no longer neccessary to patch here.
+  when (ghcFlavor /= GhcMaster) $
+    forM_ ["compiler/ghci/Linker.hs"
           , "compiler/utils/FastString.hs"
           , "compiler/main/DynFlags.hs"] $
     \file ->
@@ -556,7 +562,7 @@ ghciDef GhcMaster = ""
 ghciDef _ = "-DGHCI"
 
 ghcStageDef :: GhcFlavor -> String
-ghcStageDef GhcMaster = "-DGHC_STAGE=2"
+ghcStageDef GhcMaster = ""
 ghcStageDef _ = "-DSTAGE=2"
 
 -- | Produces a ghc-lib-parser Cabal file.


### PR DESCRIPTION
Upstream sweep to `d584e3f08cfee6e28b70bf53c573d86e44f326f8`.

Issue raised on whether we should be continuing to set the (now called) `GHC_STAGE` constant in the `cpp-options` field of the generated cabals here : https://github.com/digital-asset/ghc-lib/issues/149.