### PR TITLE
Adapt master to work with older ghc-prim

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -44,7 +44,8 @@ data GhcFlavor = Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current =    "2b113fc957a3fb6eafd10ad41a7caf11009ef4eb" -- 12/01/2019
+current =    "70e56b272492b65e41a149ec39a939e794fea66b" -- 12/20/2019
+          -- "2b113fc957a3fb6eafd10ad41a7caf11009ef4eb" -- 12/01/2019
           -- "c2991f16cb6f5b4e7cff46a394dda4247d973f44" -- 11/17/2019
           -- "73d6e508e6ce0b66bd082419effc0010b1dc9668" -- 10/31/2019
           -- "4898df1cc25132dc9e2599d4fa4e1bbc9423cda5" -- 10/30/2019

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -132,7 +132,11 @@ parsePragmasIntoDynFlags flags filepath str =
 
 dumpParseTree :: DynFlags -> Located (HsModule GhcPs) -> IO ()
 dumpParseTree flags m =
+#if defined (GHC_MASTER)
+  dumpAction flags (mkDumpStyle flags alwaysQualify) (dumpOptionsFromFlag Opt_D_dump_parsed_ast) "" FormatText $ showAstData NoBlankSrcSpan m
+#else
   dumpSDoc flags alwaysQualify Opt_D_dump_parsed_ast "" $ showAstData NoBlankSrcSpan m
+#endif
 
 stripLocs :: Located (HsModule GhcPs) -> Located (HsModule GhcPs)
 stripLocs = transformBi $ const noSrcSpan

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -37,6 +37,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
     init ghcFlavor = do
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchHeapClosures ghcFlavor
+        applyPatchGhcPrim ghcFlavor
         applyPatchDisableCompileTimeOptimizations ghcFlavor
         -- This invokes 'stack' strictly configured by
         -- 'hadrian/stack.yaml'.


### PR DESCRIPTION
Commit [`705a16df02411ec2445c9a254396a93cabe559ef`](https://gitlab.haskell.org/ghc/ghc/commit/705a16df02411ec2445c9a254396a93cabe559ef) on 12/3/2019 induces a reliance on a version of `ghc-prim` that is not available to us (we are stuck with the `ghc-prim` that ships with the building compiler).

In the absence of a better patch, this one at least enables us to continue producing `ghc-lib` builds against `HEAD`.