### PR TITLE
Reproduce https://github.com/digital-asset/ghc-lib/issues/142

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -164,7 +164,7 @@ buildDists ghcFlavor resolver = do
     -- Building of hadrian dependencies that result from the
     -- invocations of ghc-lib-gen can require some versions of these
     -- have been installed.
-    stack "build alex happy"
+    stack $ "build alex happy"
 
     -- Get a clone of ghc.
     cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
@@ -247,18 +247,18 @@ buildDists ghcFlavor resolver = do
     -- Separate the two library build commands so they are
     -- independently timed. Note that optimizations in these builds
     -- are disabled in stack.yaml via `ghc-options: -O0`.
-    stack $ "--no-terminal --interleaved-output " ++ "build ghc-lib-parser"
-    stack $ "--no-terminal --interleaved-output " ++ "build ghc-lib"
-    stack $ "--no-terminal --interleaved-output build mini-hlint mini-compile strip-locs"
+    stack $ "--no-terminal --interleaved-output " ++ "build " ++ "--ghc-options=\"-v3\" " ++ "ghc-lib-parser"
+    stack $ "--no-terminal --interleaved-output " ++ "build " ++ "--ghc-options=\"-v3\" " ++ "ghc-lib"
+    stack $ "--no-terminal --interleaved-output build " ++ "--ghc-options=\"-v3\" " ++ "mini-hlint mini-compile strip-locs"
 
     -- Run tests.
-    stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"
-    stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_fatal_error.hs"
-    stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_non_fatal_error.hs"
-    stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_respect_dynamic_pragma.hs"
-    stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_fail_unknown_pragma.hs"
-    stack "--no-terminal exec -- strip-locs examples/mini-compile/test/MiniCompileTest.hs"
-    stack "--no-terminal exec -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"
+    -- stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest.hs"
+    -- stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_fatal_error.hs"
+    -- stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_non_fatal_error.hs"
+    -- stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_respect_dynamic_pragma.hs"
+    -- stack "--no-terminal exec -- mini-hlint examples/mini-hlint/test/MiniHlintTest_fail_unknown_pragma.hs"
+    -- stack "--no-terminal exec -- strip-locs examples/mini-compile/test/MiniCompileTest.hs"
+    -- stack "--no-terminal exec -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"
 
 #if 0
     -- Skip these tests on ghc-8.8.1 (and greater) for now. See
@@ -278,7 +278,7 @@ buildDists ghcFlavor resolver = do
       resolverFlag = stackResolverOpt resolver
 
       stack :: String -> IO ()
-      stack action = cmd $ "stack " ++ resolverFlag ++ " " ++ action
+      stack action = cmd $ "stack  " ++ resolverFlag ++ " " ++ action
 
       cmd :: String -> IO ()
       cmd x = do

--- a/CI.hs
+++ b/CI.hs
@@ -260,7 +260,7 @@ buildDists ghcFlavor resolver = do
     stack "--no-terminal exec -- strip-locs examples/mini-compile/test/MiniCompileTest.hs"
     stack "--no-terminal exec -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"
 
-#if __GLASGOW_HASKELL__ >= 808 && defined (mingw32_HOST_OS)
+#if 0
     -- Skip these tests on ghc-8.8.1 (and greater) for now. See
     -- https://gitlab.haskell.org/ghc/ghc/issues/17599.
 #else

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,78 +23,78 @@ strategy:
     # -- compiler : ghc-8.4.4
 
     # ---- ghc-flavor : ghc-8.8.1
-    linux-ghc-881-844:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "lts-12.26"
-    windows-ghc-881-844:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "lts-12.26"
-    mac-ghc-881-844:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "lts-12.26"
-    # ---- ghc-flavor : ghc-8.10.1
-    # ghc-8.4 is no longer supported for bootstrapping as of
-    # https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5
-    # 09/29/2019. Subsequent removal of CPP guards in
-    # https://gitlab.haskell.org/ghc/ghc/commit/795986aaf33e2ffc233836b86a92a77366c91db2
-    # for 'InfoTable.hsc' break the compile.
+    # linux-ghc-881-844:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "lts-12.26"
+    # windows-ghc-881-844:
+    #   image: "vs2017-win2016"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "lts-12.26"
+    # mac-ghc-881-844:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "lts-12.26"
+    # # ---- ghc-flavor : ghc-8.10.1
+    # # ghc-8.4 is no longer supported for bootstrapping as of
+    # # https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5
+    # # 09/29/2019. Subsequent removal of CPP guards in
+    # # https://gitlab.haskell.org/ghc/ghc/commit/795986aaf33e2ffc233836b86a92a77366c91db2
+    # # for 'InfoTable.hsc' break the compile.
 
-    # -- compiler : ghc-8.6.5
+    # # -- compiler : ghc-8.6.5
 
-    # ---- ghc-flavor : ghc-8.8.1
-    linux-ghc-881-865:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "lts-14.3"
-    windows-ghc-881-865:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "lts-14.3"
-    mac-ghc-881-865:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "lts-14.3"
-    # ---- ghc-flavor : ghc-8.10.1
-    linux-ghc-8101-865:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "lts-14.3"
-    windows-ghc-8101-865:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "lts-14.3"
-    mac-ghc-8101-865:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "lts-14.3"
+    # # ---- ghc-flavor : ghc-8.8.1
+    # linux-ghc-881-865:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "lts-14.3"
+    # windows-ghc-881-865:
+    #   image: "vs2017-win2016"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "lts-14.3"
+    # mac-ghc-881-865:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "lts-14.3"
+    # # ---- ghc-flavor : ghc-8.10.1
+    # linux-ghc-8101-865:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-8.10.1"
+    #   resolver: "lts-14.3"
+    # windows-ghc-8101-865:
+    #   image: "vs2017-win2016"
+    #   ghc-flavor: "ghc-8.10.1"
+    #   resolver: "lts-14.3"
+    # mac-ghc-8101-865:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-8.10.1"
+    #   resolver: "lts-14.3"
 
     # -- compiler : ghc-8.8.1
 
     # ---- ghc-flavor : ghc-8.8.1
-    linux-ghc-881-881:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "nightly-2019-09-26"
+    # linux-ghc-881-881:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "nightly-2019-09-26"
     windows-ghc-881-881:
       image: "vs2017-win2016"
       ghc-flavor: "ghc-8.8.1"
       resolver: "nightly-2019-09-26"
-    mac-ghc-881-881:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-8.8.1"
-      resolver: "nightly-2019-09-26"
-    # ---- ghc-flavor : ghc-8.10.1
-    linux-ghc-8101-881:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2019-09-26"
-    mac-ghc-8101-881:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2019-09-26"
+    # mac-ghc-881-881:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-8.8.1"
+    #   resolver: "nightly-2019-09-26"
+    # # ---- ghc-flavor : ghc-8.10.1
+    # linux-ghc-8101-881:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-8.10.1"
+    #   resolver: "nightly-2019-09-26"
+    # mac-ghc-8101-881:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-8.10.1"
+    #   resolver: "nightly-2019-09-26"
     windows-ghc-8101-881:
       image: "vs2017-win2016"
       ghc-flavor: "ghc-8.10.1"
@@ -107,36 +107,36 @@ strategy:
     # -- compiler : ghc-8.6.5
 
     # ---- ghc-flavor : da-ghc-8.8.1
-    linux-da-ghc-881-865:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "da-ghc-8.8.1"
-      resolver: "lts-14.3"
-    windows-da-ghc-881-865:
-      image: "vs2017-win2016"
-      ghc-flavor: "da-ghc-8.8.1"
-      resolver: "lts-14.3"
-    mac-da-ghc-881-865:
-      image: "macOS-10.13"
-      ghc-flavor: "da-ghc-8.8.1"
-      resolver: "lts-14.3"
-    # ---- ghc-flavor : da-ghc-8.10.1 (doesn't exist)
+    # linux-da-ghc-881-865:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "da-ghc-8.8.1"
+    #   resolver: "lts-14.3"
+    # windows-da-ghc-881-865:
+    #   image: "vs2017-win2016"
+    #   ghc-flavor: "da-ghc-8.8.1"
+    #   resolver: "lts-14.3"
+    # mac-da-ghc-881-865:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "da-ghc-8.8.1"
+    #   resolver: "lts-14.3"
+    # # ---- ghc-flavor : da-ghc-8.10.1 (doesn't exist)
 
-    # -- compiler : ghc-8.8.1
+    # # -- compiler : ghc-8.8.1
 
-    # ---- ghc-flavor : da-ghc-8.8.1
-    linux-da-ghc-881-881:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "da-ghc-8.8.1"
-      resolver: "nightly-2019-09-26"
+    # # ---- ghc-flavor : da-ghc-8.8.1
+    # linux-da-ghc-881-881:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "da-ghc-8.8.1"
+    #   resolver: "nightly-2019-09-26"
     windows-da-ghc-881-881:
       image: "vs2017-win2016"
       ghc-flavor: "da-ghc-8.8.1"
       resolver: "nightly-2019-09-26"
-    mac-da-ghc-881-881:
-      image: "macOS-10.13"
-      ghc-flavor: "da-ghc-8.8.1"
-      resolver: "nightly-2019-09-26"
-    # ---- ghc-flavor : da-ghc-8.10.1 (doesn't exist)
+    # mac-da-ghc-881-881:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "da-ghc-8.8.1"
+    #   resolver: "nightly-2019-09-26"
+    # # ---- ghc-flavor : da-ghc-8.10.1 (doesn't exist)
 
     # ghc-lib master (vanilla)
 
@@ -160,35 +160,35 @@ strategy:
 
     # -- compiler : ghc-8.6.5
 
-    # ---- ghc-flavor : ghc-master
-    linux-ghc-master-865:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-master"
-      resolver: "lts-14.3"
-    windows-ghc-master-865:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-master"
-      resolver: "lts-14.3"
-    mac-ghc-master-865:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-master"
-      resolver: "lts-14.3"
+    # # ---- ghc-flavor : ghc-master
+    # linux-ghc-master-865:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-master"
+    #   resolver: "lts-14.3"
+    # windows-ghc-master-865:
+    #   image: "vs2017-win2016"
+    #   ghc-flavor: "ghc-master"
+    #   resolver: "lts-14.3"
+    # mac-ghc-master-865:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-master"
+    #   resolver: "lts-14.3"
 
-    # -- compiler : ghc-8.8.1
+    # # -- compiler : ghc-8.8.1
 
-    # ---- ghc-flavor : ghc-master
-    linux-ghc-master-881:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2019-09-26"
+    # # ---- ghc-flavor : ghc-master
+    # linux-ghc-master-881:
+    #   image: "Ubuntu 16.04"
+    #   ghc-flavor: "ghc-master"
+    #   resolver: "nightly-2019-09-26"
     windows-ghc-master-881:
       image: "vs2017-win2016"
       ghc-flavor: "ghc-master"
       resolver: "nightly-2019-09-26"
-    mac-ghc-master-881:
-      image: "macOS-10.13"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2019-09-26"
+    # mac-ghc-master-881:
+    #   image: "macOS-10.13"
+    #   ghc-flavor: "ghc-master"
+    #   resolver: "nightly-2019-09-26"
 
 pool: {vmImage: '$(image)'}
 


### PR DESCRIPTION
Don't merge this.

Enable failing 8.8.1 Windows CI tests and restrict builds to reproduce https://github.com/digital-asset/ghc-lib/issues/142.

From the command line,
```
stack runhaskell --package extra --package optparse-applicative CI.hs -- --resolver=nightly-2019-09-26  --ghc-flavor=master
```
will generate the ghc-lib cabal dists, build them (with 8.8.1) and execute the (failing) tests.

After an initial invocation of the above command, subsequent invocations of
```
stack --resolver nightly-2019-09-26 --no-terminal exec -- ghc -ignore-dot-ghci -package=ghc-lib-parser -e "print 1"
```
will re-execute the failing ghc-lib-parser test.

Expect output like,
```
2019-12-31T14:42:07.4407205Z D:\a\1\s\.stack-work\install\a5e678e4\lib\x86_64-windows-ghc-8.8.1\ghc-lib-parser-0.20191231-29EBQ12TzoD4US0pfsT33\HSghc-lib-parser-0.20191231-29EBQ12TzoD4US0pfsT33.o: unhandled PEi386 relocation type 0
2019-12-31T14:42:07.4434403Z ghc.EXE: unable to load package `ghc-lib-parser-0.20191231'
```