### PR TITLE
Sync with head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -44,7 +44,8 @@ data GhcFlavor = Ghc8101 | Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current =    "b84c09d533faf576c406ce9f7163efecf3037787" -- 12/01/2020
+current = "4056b9666a0fc5865a82fbba03e8312d7900ac5b" -- 01/04/2020
+       -- "b84c09d533faf576c406ce9f7163efecf3037787" -- 01/01/2020
 
 -- ghc-lib-gen argument generators.
 

--- a/CI.hs
+++ b/CI.hs
@@ -44,8 +44,7 @@ data GhcFlavor = Ghc8101 | Ghc881 | DaGhc881 | GhcMaster String
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "4056b9666a0fc5865a82fbba03e8312d7900ac5b" -- 01/04/2020
-       -- "b84c09d533faf576c406ce9f7163efecf3037787" -- 01/01/2020
+current = "4056b9666a0fc5865a82fbba03e8312d7900ac5b" -- 2020-01-04
 
 -- ghc-lib-gen argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,8 +20,6 @@ strategy:
   # Limit number of executors used so other pipelines can run too
   maxParallel: 10
   matrix:
-    # -- compiler : ghc-8.4.4
-
     # ---- ghc-flavor : ghc-8.8.1
     linux-ghc-881-844:
       image: "Ubuntu 16.04"

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1,5 +1,5 @@
--- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its
--- affiliates. All rights reserved.  SPDX-License-Identifier:
+-- Copyright (c) 2019-2020, Digital Asset (Switzerland) GmbH and/or
+-- its affiliates. All rights reserved.  SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 
 module Ghclibgen (
@@ -99,10 +99,9 @@ ghcLibParserHsSrcDirs forParserDepends ghcFlavor lib =
         , "compiler/llvmGen"
         , "compiler/rename"
         , "compiler/stgSyn"
-        , "compiler/stranal"
-        , "compiler/nativeGen"
-        ] ++
-        [ "compiler/deSugar" | ghcFlavor `elem` [GhcMaster, Ghc8101] && not forParserDepends]
+        , "compiler/stranal" ] ++
+        [ "compiler/nativeGen" | ghcFlavor /= GhcMaster] ++ -- Since 1/4/2020. See https://gitlab.haskell.org/ghc/ghc/commit/d561c8f6244f8280a2483e8753c38e39d34c1f01.
+        [ "compiler/deSugar"   | ghcFlavor `elem` [GhcMaster, Ghc8101] && not forParserDepends]
   in sortDiffListByLength all excludes -- Very important. See the comment on 'sortDiffListByLength' above.
 
 -- | C-preprocessor "include dirs" for 'ghc-lib'.
@@ -561,9 +560,6 @@ generateGhcLibCabal ghcFlavor = do
         ,"description: A package equivalent to the @ghc@ package, but which can be loaded on many compiler versions."
         ,"homepage: https://github.com/digital-asset/ghc-lib"
         ,"bug-reports: https://github.com/digital-asset/ghc-lib/issues"
-        -- This is a nice idea but requires a very modern cabal which
-        -- hinders uploading to hackage.
-        -- ,"exposed: False" -- automatically hide `ghc-lib` (thanks Ed Kmett!)
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++ indent dataFiles ++
         ["extra-source-files:"] ++ indent (ghcLibExtraFiles ghcFlavor) ++
@@ -632,9 +628,6 @@ generateGhcLibParserCabal ghcFlavor = do
         ,"description: A package equivalent to the @ghc@ package, but which can be loaded on many compiler versions."
         ,"homepage: https://github.com/digital-asset/ghc-lib"
         ,"bug-reports: https://github.com/digital-asset/ghc-lib/issues"
-        -- This is a nice idea but requires a very modern cabal which
-        -- hinders uploading to hackage.
-        -- ,"exposed: False" -- automatically hide `ghc-lib` (thanks Ed Kmett!)
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++ indent dataFiles ++
         ["extra-source-files:"] ++ indent (ghcLibParserExtraFiles ghcFlavor) ++

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -100,7 +100,7 @@ ghcLibParserHsSrcDirs forParserDepends ghcFlavor lib =
         , "compiler/rename"
         , "compiler/stgSyn"
         , "compiler/stranal" ] ++
-        [ "compiler/nativeGen" | ghcFlavor /= GhcMaster] ++ -- Since 1/4/2020. See https://gitlab.haskell.org/ghc/ghc/commit/d561c8f6244f8280a2483e8753c38e39d34c1f01.
+        [ "compiler/nativeGen" | ghcFlavor /= GhcMaster] ++ -- Since 2020-01-04. See https://gitlab.haskell.org/ghc/ghc/commit/d561c8f6244f8280a2483e8753c38e39d34c1f01.
         [ "compiler/deSugar"   | ghcFlavor `elem` [GhcMaster, Ghc8101] && not forParserDepends]
   in sortDiffListByLength all excludes -- Very important. See the comment on 'sortDiffListByLength' above.
 


### PR DESCRIPTION
Sync to `4056b9666a0fc5865a82fbba03e8312d7900ac5b`. Also, remove old comments that were made redundant when we switched back to `exposed: False`.