### PR TITLE
Restrict skipping Windows ghci load tests to 8.8.1 exclusively

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -237,7 +237,7 @@ buildDists ghcFlavor resolver = do
     stack "--no-terminal exec -- strip-locs examples/mini-compile/test/MiniCompileTest.hs"
     stack "--no-terminal exec -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"
 
-#if __GLASGOW_HASKELL__ >= 808 && \
+#if __GLASGOW_HASKELL__ == 808 && \
     __GLASGOW_HASKELL_PATCHLEVEL1__ == 1 && \
     defined (mingw32_HOST_OS)
     -- Skip these tests on ghc-8.8.1 (exclusively). See

--- a/CI.hs
+++ b/CI.hs
@@ -237,8 +237,10 @@ buildDists ghcFlavor resolver = do
     stack "--no-terminal exec -- strip-locs examples/mini-compile/test/MiniCompileTest.hs"
     stack "--no-terminal exec -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"
 
-#if __GLASGOW_HASKELL__ >= 808 && defined (mingw32_HOST_OS)
-    -- Skip these tests on ghc-8.8.1 (and greater) for now. See
+#if __GLASGOW_HASKELL__ >= 808 && \
+    __GLASGOW_HASKELL_PATCHLEVEL1__ == 1 && \
+    defined (mingw32_HOST_OS)
+    -- Skip these tests on ghc-8.8.1 (exclusively). See
     -- https://gitlab.haskell.org/ghc/ghc/issues/17599.
 #else
     -- Test everything loads in GHCi, see


### PR DESCRIPTION
The discussion in https://gitlab.haskell.org/ghc/ghc/issues/17599 indicates the issue described in https://github.com/digital-asset/ghc-lib/issues/142 is expected to be resolved in ghc-8.8.2. Accordingly, restrict skipping the failing Windows ghci load tests to 8.8.1 exclusively. 