### PR TITLE
Drop most 8.8.1 builds; replace with 8.8.2

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -280,7 +280,7 @@ buildDists ghcFlavor
     stack "--no-terminal exec -- mini-compile examples/mini-compile/test/MiniCompileTest.hs"
 
 #if __GLASGOW_HASKELL__ == 808 && \
-    __GLASGOW_HASKELL_PATCHLEVEL1__ == 1 && \
+    (__GLASGOW_HASKELL_PATCHLEVEL1__ == 1 || __GLASGOW_HASKELL_PATCHLEVEL1__ == 2) && \
     defined (mingw32_HOST_OS)
     -- Skip these tests on ghc-8.8.1 (exclusively). See
     -- https://gitlab.haskell.org/ghc/ghc/issues/17599.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,52 +71,19 @@ strategy:
       image: "macOS-10.14"
       ghc-flavor: "ghc-8.10.1"
       resolver: "lts-14.3"
-
-    # -- compiler : ghc-8.8.1
-
-    # ---- ghc-flavor : ghc-8.8.2
-    linux-ghc-882-881:
+    # ---- ghc-flavor : ghc-master
+    linux-ghc-master-865:
       image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.8.2"
-      resolver: "nightly-2019-09-26"
-    windows-ghc-882-881:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-8.8.2"
-      resolver: "nightly-2019-09-26"
-    mac-ghc-882-881:
-      image: "macOS-10.14"
-      ghc-flavor: "ghc-8.8.2"
-      resolver: "nightly-2019-09-26"
-    # ---- ghc-flavor : ghc-8.10.1
-    linux-ghc-8101-881:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2019-09-26"
-    mac-ghc-8101-881:
-      image: "macOS-10.14"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2019-09-26"
-    windows-ghc-8101-881:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2019-09-26"
-
-    # -- compiler : ghc-8.6.5
-
-    # ---- ghc-flavor : da-ghc-8.8.1
-    linux-da-ghc-881-865:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "da-ghc-8.8.1"
+      ghc-flavor: "ghc-master"
       resolver: "lts-14.3"
-    windows-da-ghc-881-865:
+    windows-ghc-master-865:
       image: "vs2017-win2016"
-      ghc-flavor: "da-ghc-8.8.1"
+      ghc-flavor: "ghc-master"
       resolver: "lts-14.3"
-    mac-da-ghc-881-865:
+    mac-ghc-master-865:
       image: "macOS-10.14"
-      ghc-flavor: "da-ghc-8.8.1"
+      ghc-flavor: "ghc-master"
       resolver: "lts-14.3"
-    # ---- ghc-flavor : da-ghc-8.10.1 (doesn't exist)
 
     # -- compiler : ghc-8.8.1
 
@@ -134,37 +101,48 @@ strategy:
       ghc-flavor: "da-ghc-8.8.1"
       resolver: "nightly-2019-09-26"
 
-    # -- compiler : ghc-8.6.5
+    # -- compiler : ghc-8.8.2
 
+    # ---- ghc-flavor : ghc-8.8.2
+    linux-ghc-882-882:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-8.8.2"
+      resolver: "nightly-2020-01-25"
+    windows-ghc-882-882:
+      image: "vs2017-win2016"
+      ghc-flavor: "ghc-8.8.2"
+      resolver: "nightly-2020-01-25"
+    mac-ghc-882-882:
+      image: "macOS-10.14"
+      ghc-flavor: "ghc-8.8.2"
+      resolver: "nightly-2020-01-25"
+    # ---- ghc-flavor : ghc-8.10.1
+    linux-ghc-8101-882:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-8.10.1"
+      resolver: "nightly-2020-01-25"
+    mac-ghc-8101-882:
+      image: "macOS-10.14"
+      ghc-flavor: "ghc-8.10.1"
+      resolver: "nightly-2020-01-25"
+    windows-ghc-8101-882:
+      image: "vs2017-win2016"
+      ghc-flavor: "ghc-8.10.1"
+      resolver: "nightly-2020-01-25"
     # ---- ghc-flavor : ghc-master
-    linux-ghc-master-865:
+    linux-ghc-master-882:
       image: "Ubuntu 16.04"
       ghc-flavor: "ghc-master"
-      resolver: "lts-14.3"
-    windows-ghc-master-865:
+      resolver: "nightly-2020-01-25"
+    windows-ghc-master-882:
       image: "vs2017-win2016"
       ghc-flavor: "ghc-master"
-      resolver: "lts-14.3"
-    mac-ghc-master-865:
+      resolver: "nightly-2020-01-25"
+    mac-ghc-master-882:
       image: "macOS-10.14"
       ghc-flavor: "ghc-master"
-      resolver: "lts-14.3"
+      resolver: "nightly-2020-01-25"
 
-    # -- compiler : ghc-8.8.1
-
-    # ---- ghc-flavor : ghc-master
-    linux-ghc-master-881:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2019-09-26"
-    windows-ghc-master-881:
-      image: "vs2017-win2016"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2019-09-26"
-    mac-ghc-master-881:
-      image: "macOS-10.14"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2019-09-26"
 
 pool: {vmImage: '$(image)'}
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,4 +160,4 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
       curl -sSL https://get.haskellstack.org/ | sh
       stack --resolver $(resolver) setup > /dev/null
-      stack runhaskell --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor) --verbosity=debug --cabal-verbose --resolver $(resolver)
+      stack runhaskell --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor) --resolver $(resolver)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,4 +160,4 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
       curl -sSL https://get.haskellstack.org/ | sh
       stack --resolver $(resolver) setup > /dev/null
-      stack runhaskell --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor) --resolver $(resolver)
+      stack runhaskell --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor) --verbosity=debug --cabal-verbose --resolver $(resolver)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -567,7 +567,7 @@ generateGhcLibCabal ghcFlavor = do
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++ indent dataFiles ++
         ["extra-source-files:"] ++ indent (ghcLibExtraFiles ghcFlavor) ++
-        ["tested-with: GHC==8.8.1, GHC==8.6.5, GHC==8.4.3"
+        ["tested-with: GHC==8.8.2, GHC==8.6.5, GHC==8.4.4"
         ,"source-repository head"
         ,"    type: git"
         ,"    location: git@github.com:digital-asset/ghc-lib.git"
@@ -635,7 +635,7 @@ generateGhcLibParserCabal ghcFlavor = do
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++ indent dataFiles ++
         ["extra-source-files:"] ++ indent (ghcLibParserExtraFiles ghcFlavor) ++
-        ["tested-with: GHC==8.8.1, GHC==8.6.5, GHC==8.4.3"
+        ["tested-with: GHC==8.8.2, GHC==8.6.5, GHC==8.4.4"
         ,"source-repository head"
         ,"    type: git"
         ,"    location: git@github.com:digital-asset/ghc-lib.git"


### PR DESCRIPTION
Change most ghc-8.8.1 compiler builds to ghc-8.8.2 ones (exclude Digital Asset builds). 