### PR TITLE
Move GHC.Hs.Dump to ghc-lib-parser

### DIFF
--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -47,9 +47,9 @@ import "ghc-lib-parser" Platform
 #endif
 
 #if defined (GHC_MASTER) || defined (GHC_8101)
-import "ghc-lib" GHC.Hs.Dump
+import "ghc-lib-parser" GHC.Hs.Dump
 #else
-import "ghc-lib" HsDumpAst
+import "ghc-lib-parser" HsDumpAst
 #endif
 
 import Control.Monad

--- a/examples/strip-locs/strip-locs.cabal
+++ b/examples/strip-locs/strip-locs.cabal
@@ -14,7 +14,6 @@ executable strip-locs
   build-depends:       base >=4.11
                      , extra
                      , ghc-lib-parser
-                     , ghc-lib
                      , containers
                      , uniplate
   default-language:    Haskell2010

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -295,10 +295,13 @@ calcParserModules ghcFlavor = do
       -- Lastly, manipulate text like 'GHC/Exts/Heap/Constants.hs'
       -- into 'GHC.Exts.Heap.Constants'.
       modules = map (replace "/" "." . dropSuffix ".hs") strippedModulePaths
-  -- We put 'HeaderInfo' here because doing so means clients who
-  -- just want to do parsing don't need 'ghc-lib' (this module
-  -- is needed for parsing in the presence of dynamic pragmas).
-  return $ nubSort (modules ++ ["HeaderInfo"])
+      -- The modules in this list would by default end up in
+      -- ghc-lib. We intervene so that rather, they go into
+      -- ghc-lib-parser.
+      extraModules =
+        ["HeaderInfo"] ++
+        [ if ghcFlavor `elem` [ GhcMaster, Ghc8101 ] then "GHC.Hs.Dump" else "HsDumpAst"]
+  return $ nubSort (modules ++ extraModules)
 
 -- | Selectively disable optimizations in some particular files so as
 -- to reduce (user) compile times. The files we apply this to were


### PR DESCRIPTION
Allows to use `showDataAst` without requiring ghc-lib.