### PR TITLE
Sync with head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -51,7 +51,7 @@ data GhcFlavor = Ghc8101 | Ghc881 | Ghc882 | Ghc883 | DaGhc881 | GhcMaster Strin
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "9d09411122b9b534b96e988b6d3f6d7eb04b8f66" -- 2020-02-22
+current = "04d30137771a6cf8a18fda1ced25f78d0b2eb204" -- 2020-02-29
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -100,6 +100,7 @@ ghcLibParserHsSrcDirs forParserDepends ghcFlavor lib =
         , "compiler/rename"
         , "compiler/stgSyn"
         , "compiler/stranal" ] ++
+        [ "compiler/specialise" | ghcFlavor == GhcMaster] ++
         [ "compiler/cmm" | ghcFlavor == GhcMaster] ++
         [ "compiler/nativeGen" | ghcFlavor /= GhcMaster] ++ -- Since 2020-01-04. See https://gitlab.haskell.org/ghc/ghc/commit/d561c8f6244f8280a2483e8753c38e39d34c1f01.
         [ "compiler/deSugar"   | ghcFlavor `elem` [GhcMaster, Ghc8101] && not forParserDepends]


### PR DESCRIPTION
Sync to https://gitlab.haskell.org/ghc/ghc.git `04d30137771a6cf8a18fda1ced25f78d0b2eb204`
- Exclude `compiler/specialise` from ghc-lib-parser Hs src dirs (it no longer exists).