### PR TITLE
Add ghc-8.10.1 build support and framework for bounds testing 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,75 +20,123 @@ strategy:
   # Limit number of executors used so other pipelines can run too
   maxParallel: 10
   matrix:
-    # --- ghc-flavor : ghc-8.11
-    # ghc-8.8 becomes the new minimum for bootstrapping as of
-    # https://gitlab.haskell.org/ghc/ghc/-/commit/57b888c0e90be7189285a6b078c30b26d0923809 2020/03/31
+    # Notes:
+    #  Tags are encoded in the following way:
+    #        <os> '-' <ghc-lib> '-' <compiler>
+    #  Not every combination is tested
+    #  - We do sampling to keep the number of builds reasonable;
+    #  - No ghc-8.4.4 builds are tested;
+    #  - No Windows 8.8.3 builds are tested (ghc-8.8.3 on Windows
+    #    has issues);
+    #  - Minimum GHC needed to bootstrap:
+    #      +--------------+------------+
+    #      | GHC flavor   |  version   |
+    #      +==============+============+
+    #      | ghc-8.8.*    |  >= 8.4.4  |
+    #      | ghc-8.10.*   |  >= 8.6.5  | (since 09/29/2019, https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5)
+    #      | ghc-8.11.*   |  >= 8.8.1  | (since 2020/03/31, https://gitlab.haskell.org/ghc/ghc/-/commit/57b888c0e90be7189285a6b078c30b26d092380)
+    #      +--------------+------------+
 
-    # ---- ghc-flavor : ghc-8.10.1
-    # ghc-8.4 is no longer supported for bootstrapping as of
-    # https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5
-    # 09/29/2019. Subsequent removal of CPP guards in
-    # https://gitlab.haskell.org/ghc/ghc/commit/795986aaf33e2ffc233836b86a92a77366c91db2
-    # for 'InfoTable.hsc' break the compile.
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-master      | ghc-8.10.1 |
+    # +---------+-----------------+------------+
+    linux-ghc-master-8.10.1:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-master"
+      resolver: "ghc-8.10.1"
+      stack-yaml: "stack-exact.yaml"
 
-    # -- compiler : ghc-8.8.1
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-8.10.1      | ghc-8.10.1 |
+    # | macOS   | ghc-8.10.1      | ghc-8.10.1 |
+    # +---------+-----------------+------------+
+    linux-ghc-8.10.1-8.10.1:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-8.10.1"
+      resolver: "ghc-8.10.1"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-8.10.1-8.10.1:
+      image: "macOS-10.14"
+      ghc-flavor: "ghc-8.10.1"
+      resolver: "ghc-8.10.1"
+      stack-yaml: "stack-exact.yaml"
 
-    # ---- ghc-flavor : da-ghc-8.8.1
-    linux-da-ghc-881-881:
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-8.8.3       | ghc-8.10.1 |
+    # | macOS   | ghc-8.8.3       | ghc-8.10.1 |
+    # +---------+-----------------+------------+
+    linux-ghc-8.8.3-8.10.1:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-8.8.3"
+      resolver: "ghc-8.10.1"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-8.8.3-8.10.1:
+      image: "macOS-10.14"
+      ghc-flavor: "ghc-8.8.3"
+      resolver: "ghc-8.10.1"
+      stack-yaml: "stack-exact.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-master      | ghc-8.8.3  |
+    # +---------+-----------------+------------+
+    linux-ghc-master-8.8.3:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-master"
+      stack-yaml: "stack.yaml"
+      resolver: "nightly-2020-03-14"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | macOS   | ghc-8.8.3       | ghc-8.8.3  |
+    # +---------+-----------------+------------+
+    mac-ghc-8.8.3-8.8.3:
+      image: "macOS-10.14"
+      ghc-flavor: "ghc-8.8.3"
+      resolver: "nightly-2020-03-14"
+      stack-yaml: "stack.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-8.10.1      | ghc-8.8.3  |
+    # +---------+-----------------+------------+
+    linux-ghc-8.10.1-8.8.3:
+      image: "Ubuntu 16.04"
+      ghc-flavor: "ghc-8.10.1"
+      resolver: "nightly-2020-03-14"
+      stack-yaml: "stack.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | da-ghc-8.8.1    | ghc-8.8.1  |
+    # | windows | da-ghc-8.8.1    | ghc-8.8.1  |
+    # | macOS   | da-ghc-8.8.1    | ghc-8.8.1  |
+    # +---------+-----------------+------------+
+    linux-da-ghc-8.8.1-8.8.1:
       image: "Ubuntu 16.04"
       ghc-flavor: "da-ghc-8.8.1"
       resolver: "nightly-2019-09-26"
-    windows-da-ghc-881-881:
+      stack-yaml: "stack.yaml"
+    windows-da-ghc-8.8.1-8.8.1:
       image: "vs2017-win2016"
       ghc-flavor: "da-ghc-8.8.1"
       resolver: "nightly-2019-09-26"
-    mac-da-ghc-881-881:
+      stack-yaml: "stack.yaml"
+    mac-da-ghc-8.8.1-8.8.1:
       image: "macOS-10.14"
       ghc-flavor: "da-ghc-8.8.1"
       resolver: "nightly-2019-09-26"
-
-    # -- compiler : ghc-8.8.3
-
-    # ---- ghc-flavor : ghc-8.8.3
-    linux-ghc-883-883:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.8.3"
-      resolver: "nightly-2020-03-14"
-    # windows-ghc-883-883:
-    #   image: "vs2017-win2016"
-    #   ghc-flavor: "ghc-8.8.3"
-    #   resolver: "nightly-2020-03-14"
-    mac-ghc-883-883:
-      image: "macOS-10.14"
-      ghc-flavor: "ghc-8.8.3"
-      resolver: "nightly-2020-03-14"
-    # ---- ghc-flavor : ghc-8.10.1
-    linux-ghc-8101-883:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2020-03-14"
-    mac-ghc-8101-883:
-      image: "macOS-10.14"
-      ghc-flavor: "ghc-8.10.1"
-      resolver: "nightly-2020-03-14"
-    # windows-ghc-8101-883:
-    #   image: "vs2017-win2016"
-    #   ghc-flavor: "ghc-8.10.1"
-    #   resolver: "nightly-2020-03-14"
-    # ---- ghc-flavor : ghc-master
-    linux-ghc-master-883:
-      image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2020-03-14"
-    # windows-ghc-master-883:
-    #   image: "vs2017-win2016"
-    #   ghc-flavor: "ghc-master"
-    #   resolver: "nightly-2020-03-14"
-    mac-ghc-master-883:
-      image: "macOS-10.14"
-      ghc-flavor: "ghc-master"
-      resolver: "nightly-2020-03-14"
-
+      stack-yaml: "stack.yaml"
 
 pool: {vmImage: '$(image)'}
 
@@ -106,5 +154,5 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/src
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
       curl -sSL https://get.haskellstack.org/ | sh
-      stack --resolver $(resolver) setup > /dev/null
-      stack runhaskell --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor) --resolver $(resolver)
+      stack --stack-yaml $(stack-yaml) --resolver $(resolver) setup > /dev/null
+      stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor)  --stack-yaml $(stack-yaml) --resolver $(resolver)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -566,7 +566,7 @@ generateGhcLibCabal ghcFlavor = do
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++ indent dataFiles ++
         ["extra-source-files:"] ++ indent (ghcLibExtraFiles ghcFlavor) ++
-        ["tested-with: GHC==8.8.2, GHC==8.6.5, GHC==8.4.4"
+        ["tested-with: GHC==8.10.1, GHC==8.8.2, GHC==8.6.5, GHC==8.4.4"
         ,"source-repository head"
         ,"    type: git"
         ,"    location: git@github.com:digital-asset/ghc-lib.git"
@@ -634,7 +634,7 @@ generateGhcLibParserCabal ghcFlavor = do
         ,"data-dir: " ++ dataDir
         ,"data-files:"] ++ indent dataFiles ++
         ["extra-source-files:"] ++ indent (ghcLibParserExtraFiles ghcFlavor) ++
-        ["tested-with: GHC==8.8.2, GHC==8.6.5, GHC==8.4.4"
+        ["tested-with: GHC==8.10.1, GHC==8.8.2, GHC==8.6.5, GHC==8.4.4"
         ,"source-repository head"
         ,"    type: git"
         ,"    location: git@github.com:digital-asset/ghc-lib.git"

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -1,0 +1,64 @@
+# To use this, the command you want is:
+#  stack runhaskell \
+#    --stack-yaml stack-exact.yaml \
+#    --package extra --package optparse-applicative \
+#    CI.hs -- \
+#    --stack-yaml stack-exact.yaml --ghc-flavor xxx
+# You can add --resolver xxx to the above command to have the effet of
+# overriding the choice of compiler if desired.
+
+# Stack 8.10 builds generate a lot of warnings of this kind.
+#   Warning: Failed to decode module interface:
+#            some/path/to/Main.hi
+#            Decoding failure: Invalid magic: e49ceb0f
+# This is a known upstream issue (see
+# https://github.com/commercialhaskell/stack/issues/5134).
+
+resolver: ghc-8.10.1
+# No resolver, only packages shipped with the compiler
+# i.e. base-4.14.0.0, ghc-prim-0.6.1, hpc-0.6.1.0.
+
+ghc-options:
+  # Try to be quick.
+  "$everything": -O0 -j
+
+extra-deps:
+# Dependencies of ghc-lib-parser & ghc-lib:
+- alex-3.2.5
+- array-0.5.4.0
+- binary-0.8.8.0
+- bytestring-0.10.10.0
+- containers-0.6.2.1
+- deepseq-1.4.4.0
+- directory-1.3.6.0
+- filepath-1.4.2.1
+- happy-1.19.12
+- pretty-1.1.3.6
+- process-1.6.8.2
+- time-1.9.3
+- transformers-0.5.6.2
+- unix-2.7.2.2
+# Dependencies for ghc-lib examples:
+- hashable-1.3.0.0
+- syb-0.7.1
+- uniplate-1.6.12
+- unordered-containers-0.2.10.0
+# Additional dependencies for CI.hs & ghc-lib-gen:
+- ansi-terminal-0.10.3
+- ansi-wl-pprint-0.6.9
+- clock-0.8
+- colour-2.3.5
+- extra-1.7.1
+- mintty-0.1.2 # Windows specific (but it does no harm).
+- optparse-applicative-0.15.1.0
+- semigroups-0.19.1
+- transformers-compat-0.6.5
+
+flags:
+  transformers-compat:
+    five-three: true
+
+# Packages MUST go at the end, since we append to it during the CI.hs
+# script.
+packages:
+- .


### PR DESCRIPTION
Add support for building/testing with ghc-8.10.1 and a framework for bounds testing. Closes https://github.com/digital-asset/ghc-lib/issues/197.