### PR TITLE
Add patch HsVersions.h -> GhclibHsVersions.h

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -35,6 +35,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
   where
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
+        applyPatchHsVersions ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor
         applyPatchDisableCompileTimeOptimizations ghcFlavor


### PR DESCRIPTION
Add a patch step that renames `HsVersions.h` to `GhclibHsVersions.h`. This enables ghc-lib-parser to be used in conjunction with ghcjs. Fixes https://github.com/digital-asset/ghc-lib/issues/204.