### PR TITLE
Obfuscate ghc heap symbols

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -36,6 +36,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
         applyPatchHsVersions ghcFlavor
+        applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor
         applyPatchDisableCompileTimeOptimizations ghcFlavor


### PR DESCRIPTION
Duplicate symbol errors arise on Windows when linking with ghc-lib-parser with ghc-heap. Syntactically obfuscate ghc-lib's `aToWordzh` and `reallyUnsafePtrEqualityUpToTag` to avoid this.  Fixes https://github.com/digital-asset/ghc-lib/issues/210.