### PR TITLE
more flexible da flavour

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -28,7 +28,7 @@ main = do
     let opts =
           Opts.info (parseOptions Opts.<**> Opts.helper)
           ( Opts.fullDesc
-            <> Opts.progDesc "Build (and possibly upload) ghc-lib and ghc-lib-parser tarballs."
+            <> Opts.progDesc "Build ghc-lib and ghc-lib-parser tarballs."
             <> Opts.header "CI - CI script for ghc-lib"
           )
     Options { ghcFlavor, stackOptions } <- Opts.execParser opts
@@ -126,20 +126,20 @@ parseOptions = Options
    parseDaOptions =
        Opts.flag' Da ( Opts.long "da" <> Opts.help "Enables DA custom build." )
        <*> Opts.strOption
-           ( Opts.long "da-merge-base-sha"
+           ( Opts.long "merge-base-sha"
           <> Opts.help "DA flavour only. Base commit to use from the GHC repo."
           <> Opts.showDefault
           <> Opts.value "ghc-8.8.1-release"
            )
        <*> (Opts.some
              (Opts.strOption
-              ( Opts.long "da-patch"
-             <> Opts.help "DA flavour only. Commits to merge in from the DA GHC fork, referenced as 'upstream'. Can be specified multiple times. If no patch is specified, default will be equivalent to `--da-patch upstream/da-master-8.8.1 --da-patch upstream/da-unit-ids-8.8.1`. Specifying any patch will overwrite the default (i.e. replace, not add)."
+              ( Opts.long "patch"
+             <> Opts.help "DA flavour only. Commits to merge in from the DA GHC fork, referenced as 'upstream'. Can be specified multiple times. If no patch is specified, default will be equivalent to `--patch upstream/da-master-8.8.1 --patch upstream/da-unit-ids-8.8.1`. Specifying any patch will overwrite the default (i.e. replace, not add)."
               ))
             Opts.<|>
             pure ["upstream/da-master-8.8.1", "upstream/da-unit-ids-8.8.1"])
        <*> Opts.strOption
-           ( Opts.long "da-gen-flavor"
+           ( Opts.long "gen-flavor"
           <> Opts.help "DA flavor only. Flavor to pass on to ghc-lib-gen."
           <> Opts.showDefault
           <> Opts.value "da-ghc-8.8.1")

--- a/CI.hs
+++ b/CI.hs
@@ -52,10 +52,7 @@ data GhcFlavor = Ghc8101
                | Ghc881
                | Ghc882
                | Ghc883
-               | Da { mergeBaseSha :: String
-                    , patches :: [String]
-                    , flavor :: String
-                    }
+               | Da { mergeBaseSha :: String , patches :: [String] , flavor :: String }
                | GhcMaster String
   deriving (Eq, Show)
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ general case: the `--ghc-flavor` flag is replaced with an "enabling" flag
 stack runhaskell --package extra \
                  --package optparse-applicative \
                  CI.hs -- --da \
-                          --da-merge-base-sha=ghc-8.8.1-release \
-                          --da-patch=upstream/da-master-8.8.1 \
-                          --da-patch=upstream/da-unit-ids-8.8.1 \
-                          --da-gen-flavor=da-ghc-8.8.1
+                          --merge-base-sha=ghc-8.8.1-release \
+                          --patch=upstream/da-master-8.8.1 \
+                          --patch=upstream/da-unit-ids-8.8.1 \
+                          --gen-flavor=da-ghc-8.8.1
 ```
 
 The DAML-specific process only differs from the normal one in that it patches
@@ -74,13 +74,13 @@ GHC with the given patches. More specifically, it will:
 - Clone GHC. (This is also done by the normal workflow.)
 - Add the [DA fork](https://github.com/digital-asset/ghc/) of GHC as a remote
   named `upstream`.
-- Checkout the commit provided as `da-merge-base-sha`.
+- Checkout the commit provided as `merge-base-sha`.
 - Create a new commit by merging in all of the commits specified through the
-  `--da-patch` flags.
+  `--patch` flags.
 - Proceed as normal for the rest of the workflow.
 
 At some later stage, the workflow calls out to the `ghc-lib-gen` program, and
 at that point it needs to pass in a "flavor" argument; it will use the value of
-the `--da-flavor` option for that.
+the `--gen-flavor` option for that.
 
 Note that deployment for the DAML version is handled from within the DAML CI.

--- a/README.md
+++ b/README.md
@@ -49,3 +49,38 @@ stack runhaskell --package extra --package optparse-applicative CI.hs -- --ghc-f
 ## Releasing `ghc-lib` (notes for maintainers)
 
 Build `ghc-lib` using the [above instructions](#building-ghc-lib)  and upload the resulting `.tar.gz` files to [Hackage](https://hackage.haskell.org/upload).
+
+# Building `ghc-lib` for DAML
+
+The [`CI.hs`](CI.hs) script has special support for building custom versions of
+ghc-lib specifically tailored to the DAML compiler, which requires a handful of
+patches to be applied on top of GHC. The syntax is slightly different from the
+general case: the `--ghc-flavor` flag is replaced with an "enabling" flag
+`--da` and three more specific flags. A full call example would be:
+
+```
+stack runhaskell --package extra \
+                 --package optparse-applicative \
+                 CI.hs -- --da \
+                          --da-merge-base-sha=ghc-8.8.1-release \
+                          --da-patch=upstream/da-master-8.8.1 \
+                          --da-patch=upstream/da-unit-ids-8.8.1 \
+                          --da-gen-flavor=da-ghc-8.8.1
+```
+
+The DAML-specific process only differs from the normal one in that it patches
+GHC with the given patches. More specifically, it will:
+
+- Clone GHC. (This is also done by the normal workflow.)
+- Add the [DA fork](https://github.com/digital-asset/ghc/) of GHC as a remote
+  named `upstream`.
+- Checkout the commit provided as `da-merge-base-sha`.
+- Create a new commit by merging in all of the commits specified through the
+  `--da-patch` flags.
+- Proceed as normal for the rest of the workflow.
+
+At some later stage, the workflow calls out to the `ghc-lib-gen` program, and
+at that point it needs to pass in a "flavor" argument; it will use the value of
+the `--da-flavor` option for that.
+
+Note that deployment for the DAML version is handled from within the DAML CI.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,17 +124,17 @@ strategy:
     # +---------+-----------------+------------+
     linux-da-ghc-8.8.1-8.8.1:
       image: "Ubuntu 16.04"
-      ghc-flavor: "da-ghc-8.8.1"
+      ghc-flavor: "da"
       resolver: "nightly-2019-09-26"
       stack-yaml: "stack.yaml"
     windows-da-ghc-8.8.1-8.8.1:
       image: "vs2017-win2016"
-      ghc-flavor: "da-ghc-8.8.1"
+      ghc-flavor: "da"
       resolver: "nightly-2019-09-26"
       stack-yaml: "stack.yaml"
     mac-da-ghc-8.8.1-8.8.1:
       image: "macOS-10.14"
-      ghc-flavor: "da-ghc-8.8.1"
+      ghc-flavor: "da"
       resolver: "nightly-2019-09-26"
       stack-yaml: "stack.yaml"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ strategy:
     # +---------+-----------------+------------+
     linux-ghc-master-8.10.1:
       image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-master"
+      mode: "--ghc-flavor ghc-master"
       resolver: "ghc-8.10.1"
       stack-yaml: "stack-exact.yaml"
 
@@ -56,12 +56,12 @@ strategy:
     # +---------+-----------------+------------+
     linux-ghc-8.10.1-8.10.1:
       image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.10.1"
+      mode: "--ghc-flavor ghc-8.10.1"
       resolver: "ghc-8.10.1"
       stack-yaml: "stack-exact.yaml"
     mac-ghc-8.10.1-8.10.1:
       image: "macOS-10.14"
-      ghc-flavor: "ghc-8.10.1"
+      mode: "--ghc-flavor ghc-8.10.1"
       resolver: "ghc-8.10.1"
       stack-yaml: "stack-exact.yaml"
 
@@ -73,12 +73,12 @@ strategy:
     # +---------+-----------------+------------+
     linux-ghc-8.8.3-8.10.1:
       image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.8.3"
+      mode: "--ghc-flavor ghc-8.8.3"
       resolver: "ghc-8.10.1"
       stack-yaml: "stack-exact.yaml"
     mac-ghc-8.8.3-8.10.1:
       image: "macOS-10.14"
-      ghc-flavor: "ghc-8.8.3"
+      mode: "--ghc-flavor ghc-8.8.3"
       resolver: "ghc-8.10.1"
       stack-yaml: "stack-exact.yaml"
 
@@ -89,7 +89,7 @@ strategy:
     # +---------+-----------------+------------+
     linux-ghc-master-8.8.3:
       image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-master"
+      mode: "--ghc-flavor ghc-master"
       stack-yaml: "stack.yaml"
       resolver: "nightly-2020-03-14"
 
@@ -100,7 +100,7 @@ strategy:
     # +---------+-----------------+------------+
     mac-ghc-8.8.3-8.8.3:
       image: "macOS-10.14"
-      ghc-flavor: "ghc-8.8.3"
+      mode: "--ghc-flavor ghc-8.8.3"
       resolver: "nightly-2020-03-14"
       stack-yaml: "stack.yaml"
 
@@ -111,7 +111,7 @@ strategy:
     # +---------+-----------------+------------+
     linux-ghc-8.10.1-8.8.3:
       image: "Ubuntu 16.04"
-      ghc-flavor: "ghc-8.10.1"
+      mode: "--ghc-flavor ghc-8.10.1"
       resolver: "nightly-2020-03-14"
       stack-yaml: "stack.yaml"
 
@@ -124,17 +124,17 @@ strategy:
     # +---------+-----------------+------------+
     linux-da-ghc-8.8.1-8.8.1:
       image: "Ubuntu 16.04"
-      ghc-flavor: "da"
+      mode: "--da"
       resolver: "nightly-2019-09-26"
       stack-yaml: "stack.yaml"
     windows-da-ghc-8.8.1-8.8.1:
       image: "vs2017-win2016"
-      ghc-flavor: "da"
+      mode: "--da"
       resolver: "nightly-2019-09-26"
       stack-yaml: "stack.yaml"
     mac-da-ghc-8.8.1-8.8.1:
       image: "macOS-10.14"
-      ghc-flavor: "da"
+      mode: "--da"
       resolver: "nightly-2019-09-26"
       stack-yaml: "stack.yaml"
 
@@ -155,4 +155,4 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
       curl -sSL https://get.haskellstack.org/ | sh
       stack --stack-yaml $(stack-yaml) --resolver $(resolver) setup > /dev/null
-      stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs --ghc-flavor $(ghc-flavor)  --stack-yaml $(stack-yaml) --resolver $(resolver)
+      stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs $(mode)  --stack-yaml $(stack-yaml) --resolver $(resolver)


### PR DESCRIPTION
This PR updates the `CI.hs` script to make the DAML-specific build more flexible. The motivation for this change is to set up a fully auditable CI process for the DAML repo, i.e. one in which we can specify (and track) exactly which commits were involved in creating the version of ghc-lib used by the DAML compiler.