### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -58,7 +58,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "a3d69dc6c2134afe239caf4f881ba5542d2c2be0" -- 2020-06-26
+current = "85310fb83fdb7d7294bd453026102fc42000bf14" -- 2020-06-30
 
 -- Command line argument generators.
 


### PR DESCRIPTION
Sync to https://gitlab.haskell.org/ghc/ghc.git `bfa5698b1ab0190820a2df19487d3d72d3a7924d`.

Traditionally, we push to hackage on the 1st of each month. If you'd like to keep doing that I can probably take care of that today - let me know!