### PR TITLE
Sync head : hscTarget, derived constants

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "c0979cc53442b3a6202acab9cf164f0a4beea0b7" -- 2020-07-17
+current = "dff1cb3d9c111808fec60190747272b973547c52" -- 2020-07-24
 
 -- Command line argument generators.
 

--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "dff1cb3d9c111808fec60190747272b973547c52" -- 2020-07-24
+current = "fc0f6fbcd95f2dc69a8efabbee2d8a485c34cc47" -- 2020-07-25
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -82,7 +82,11 @@ mkDynFlags filename s = do
   let baseFlags =
         (defaultDynFlags fakeSettings fakeLlvmConfig) {
           ghcLink = NoLink
+#if defined(GHC_MASTER)
+        , backend = NoBackend
+#else
         , hscTarget = HscNothing
+#endif
 #if defined(GHC_MASTER)
         , unitDatabases = Just []
 #else

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -180,11 +180,15 @@ fakeSettings = Settings
       , platformIsCrossCompiling=False
       , platformLeadingUnderscore=False
       , platformTablesNextToCode=False
+      , platformConstants=platformConstants
       ,
 #endif
-#if defined (GHC_MASTER) || defined (GHC_8101)
-        platformWordSize = PW8
-      , platformMini = PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
+#if defined(GHC_MASTER)
+        platformWordSize=PW8
+      , platformArchOS=ArchOS ArchUnknown OSUnknown
+#elif defined (GHC_8101)
+        platformWordSize=PW8
+      , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
 #else
         platformWordSize=8
       , platformOS=OSUnknown

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -117,11 +117,15 @@ fakeSettings = Settings
       , platformIsCrossCompiling=False
       , platformLeadingUnderscore=False
       , platformTablesNextToCode=False
+      , platformConstants=platformConstants
       ,
 #endif
-#if defined (GHC_MASTER) || defined (GHC_8101)
-        platformWordSize = PW8
-      , platformMini = PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
+#if defined(GHC_MASTER)
+        platformWordSize=PW8
+      , platformArchOS=ArchOS ArchUnknown OSUnknown
+#elif defined (GHC_8101)
+        platformWordSize=PW8
+      , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
 #else
         platformWordSize=8
       , platformOS=OSUnknown

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -123,18 +123,20 @@ fakeSettings = Settings
       , platformIsCrossCompiling=False
       , platformLeadingUnderscore=False
       , platformTablesNextToCode=False
+      , platformConstants=platformConstants
       ,
 #endif
-
-#if defined (GHC_MASTER) || defined (GHC_8101)
-             platformWordSize=PW8
-             , platformMini = PlatformMini {platformMini_os=OSUnknown}
-             , platformUnregisterised=True
+#if defined(GHC_MASTER)
+        platformWordSize=PW8
+      , platformArchOS=ArchOS ArchUnknown OSUnknown
+#elif defined (GHC_8101)
+        platformWordSize=PW8
+      , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
 #else
-             platformWordSize=8
-             , platformOS=OSUnknown
-             , platformUnregisterised=True
+        platformWordSize=8
+      , platformOS=OSUnknown
 #endif
+      , platformUnregisterised=True
     }
     platformConstants =
       PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -175,11 +175,15 @@ includesDependencies ghcFlavor =
 derivedConstantsDependencies :: GhcFlavor -> [FilePath]
 derivedConstantsDependencies ghcFlavor =
    map (root </>)
-     [ "DerivedConstants.h"
-     , "GHCConstantsHaskellExports.hs"
-     , "GHCConstantsHaskellType.hs"
-     , "GHCConstantsHaskellWrappers.hs"
-     ]
+     ([ "DerivedConstants.h"
+      ] ++
+      [ x | ghcFlavor /= GhcMaster
+        , x <- [ "GHCConstantsHaskellExports.hs"
+               , "GHCConstantsHaskellWrappers.hs"
+               , "GHCConstantsHaskellType.hs"
+               ]
+      ]
+     )
    where
       root =
         case ghcFlavor of
@@ -206,7 +210,11 @@ compilerDependencies ghcFlavor =
     , "primop-vector-tys.hs-incl"
     , "primop-vector-uniques.hs-incl"
     ] ++
-    [ "primop-docs.hs-incl" | ghcFlavor == GhcMaster ]
+    [ x | ghcFlavor == GhcMaster
+        , x <- [ "primop-docs.hs-incl"
+               , "GHC/Platform/Constants.hs"
+               ]
+    ]
 
 platformH :: GhcFlavor -> [FilePath]
 platformH ghcFlavor =
@@ -216,6 +224,7 @@ packageCode :: GhcFlavor -> [FilePath]
 packageCode ghcFlavor =
   [ stage0Compiler </> "Config.hs" | ghcFlavor /= GhcMaster ] ++
   [ stage0Compiler </> "GHC/Settings/Config.hs" | ghcFlavor == GhcMaster ] ++
+  [ stage0Compiler </> "GHC/Platform/Constants.hs" | ghcFlavor == GhcMaster ] ++
   [ stage0GhcBoot  </> "GHC/Version.hs" | ghcFlavor `elem` [ GhcMaster, Ghc8101 ] ]
 
 fingerprint :: GhcFlavor -> [FilePath]


### PR DESCRIPTION
Sync to https://gitlab.haskell.org/ghc/ghc.git `dff1cb3d9c111808fec60190747272b973547c52`.
- Update `hscTarget` to account for https://gitlab.haskell.org/ghc/ghc/-/commit/f7cc431341e5b5b31758eecc8504cae8b2390c10.