### PR TITLE
Use ArchOS record field labels

### DIFF
--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -185,7 +185,7 @@ fakeSettings = Settings
 #endif
 #if defined(GHC_MASTER)
         platformWordSize=PW8
-      , platformArchOS=ArchOS ArchUnknown OSUnknown
+      , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
 #elif defined (GHC_8101)
         platformWordSize=PW8
       , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -122,7 +122,7 @@ fakeSettings = Settings
 #endif
 #if defined(GHC_MASTER)
         platformWordSize=PW8
-      , platformArchOS=ArchOS ArchUnknown OSUnknown
+      , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
 #elif defined (GHC_8101)
         platformWordSize=PW8
       , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -128,7 +128,7 @@ fakeSettings = Settings
 #endif
 #if defined(GHC_MASTER)
         platformWordSize=PW8
-      , platformArchOS=ArchOS ArchUnknown OSUnknown
+      , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
 #elif defined (GHC_8101)
         platformWordSize=PW8
       , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}


### PR DESCRIPTION
The last commit of MR https://gitlab.haskell.org/ghc/ghc/-/merge_requests/3666 adds field labels for `data ArchOS`. This PR makes use of them.