### PR TITLE
Sync head; fix default extensions; rename homeUnitId

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -60,7 +60,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "db6dd810eb7986a39657f7f028f1f4de92b321dd" -- 2020-08-12
+current = "8a51b2ab7433c06bddca9699b0dfd8ab1d11879b" -- 2020-08-14
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -100,7 +100,7 @@ mkDynFlags filename s = do
         , thisInstalledUnitId = toInstalledUnitId (stringToUnitId "daml-prim")
 #else
 #if defined (GHC_MASTER)
-        , homeUnitId = toUnitId (stringToUnit "ghc-prim")
+        , homeUnitId_ = toUnitId (stringToUnit "ghc-prim")
 #else
         , thisInstalledUnitId = toInstalledUnitId (stringToUnitId "ghc-prim")
 #endif

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -657,7 +657,6 @@ generateGhcLibCabal ghcFlavor = do
         , ""
         , "library"
         , "    default-language:   Haskell2010"
-        , "    default-extensions: NoImplicitPrelude"
         , "    exposed: False"
         , "    include-dirs:"
         ] ++
@@ -673,9 +672,8 @@ generateGhcLibCabal ghcFlavor = do
         ] ++
         indent2 (withCommas (commonBuildDepends ghcFlavor ++ [ "ghc-lib-parser" ]))++
         [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
-        , "    other-extensions:"
-        ] ++
-        indent2 (askField lib "other-extensions:") ++
+        , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
+        [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "    hs-source-dirs:" ] ++
         indent2 (ghcLibHsSrcDirs ghcFlavor lib) ++
         [ "    autogen-modules:"
@@ -731,7 +729,6 @@ generateGhcLibParserCabal ghcFlavor = do
         , ""
         , "library"
         , "    default-language:   Haskell2010"
-        , "    default-extensions: NoImplicitPrelude"
         , "    exposed: False"
         , "    include-dirs:"] ++ indent2 (ghcLibParserIncludeDirs ghcFlavor) ++
         [ "    ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
@@ -744,9 +741,8 @@ generateGhcLibParserCabal ghcFlavor = do
         , "    build-depends:"
         ] ++ indent2 (withCommas (commonBuildDepends ghcFlavor)) ++
         [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
-        , "    other-extensions:"
-        ] ++
-        indent2 (askField lib "other-extensions:") ++
+        , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
+        [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "    c-sources:" ] ++
         -- List CMM sources here. Go figure! (see
         -- https://twitter.com/smdiehl/status/1231958702141431808?s=20


### PR DESCRIPTION
- Sync https://gitlab.haskell.org/ghc/ghc.git `8a51b2ab7433c06bddca9699b0dfd8ab1d11879b`;
- Stop assuming the `default-extensions` field is static and populate it properly;
- `homeUnitId` -> `homeUnitId_`.