### PR TITLE
Sync head; fixup for genSym

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -60,7 +60,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "8a51b2ab7433c06bddca9699b0dfd8ab1d11879b" -- 2020-08-14
+current = "3f50154591ada9064351ccec4adfe6df53ca2439" -- 2020-08-22
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -475,13 +475,16 @@ mangleCSymbols ghcFlavor = do
         prefixSymbol genSym .
         prefixSymbol initGenSym
         =<< readFile' file
-    let file =
+    let files =
           if ghcFlavor == GhcMaster
           then
-            "compiler/GHC/Types/Unique/Supply.hs"
+            [ "compiler/GHC/Types/Unique/Supply.hs"
+            , "compiler/GHC/Types/Unique.hs"
+            ]
           else
-            "compiler/basicTypes/UniqSupply.hs"
-      in writeFile file .
+            [ "compiler/basicTypes/UniqSupply.hs" ]
+    forM_ files $ \file ->
+        writeFile file .
         prefixForeignImport genSym .
         prefixForeignImport initGenSym
         =<< readFile' file


### PR DESCRIPTION
Sync to https://gitlab.haskell.org/ghc/ghc.git `3f50154591ada9064351ccec4adfe6df53ca2439`. Add file "compiler/GHC/Types/Unique.hs" to `mangleCSymbols` for `genSym` substitution per [mkUnique refactoring commit](https://gitlab.haskell.org/ghc/ghc/-/commit/e67ae884ebe42cb31fc4230301a5f555ae23cce8#598aebb67cf4996e7c7414ec0bef247e3b5e0d73)