### PR TITLE
On ghc-8.10.*, add missing import to CmmParse fixing ghc-lib build error

### DIFF
--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -32,6 +32,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         generateGhcLibParserCabal ghcFlavor
       Ghclib -> do
         init ghcFlavor
+        applyPatchCmmParseNoImplicitPrelude ghcFlavor
         generateGhcLibCabal ghcFlavor
   where
     init :: GhcFlavor -> IO ()


### PR DESCRIPTION
Fixes https://github.com/digital-asset/ghc-lib/issues/243. No idea why the issue doesn't manifest in CI; given though that the underlying resolution is already applied to master it doesn't seem worth spending more time looking at this. 