### PR TITLE
sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -56,7 +56,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "d7385f7077c6258c2a76ae51b4ea80f6fa9c7015" -- 2020-09-23
+current = "a9ce159ba58ca7e8946b46e19b1361588b677a26" -- 2020-09-27
 
 -- Command line argument generators.
 

--- a/CI.hs
+++ b/CI.hs
@@ -56,7 +56,7 @@ data GhcFlavor = Ghc8101
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "057db94ce038970b14df1599fe83097c284b9c1f" -- 2020-09-20
+current = "d7385f7077c6258c2a76ae51b4ea80f6fa9c7015" -- 2020-09-23
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,17 +125,17 @@ strategy:
     linux-da-ghc-8.8.1-8.8.1:
       image: "Ubuntu 16.04"
       mode: "--da"
-      resolver: "nightly-2019-09-26"
+      resolver: "nightly-2020-01-08"
       stack-yaml: "stack.yaml"
     windows-da-ghc-8.8.1-8.8.1:
       image: "vs2017-win2016"
       mode: "--da"
-      resolver: "nightly-2019-09-26"
+      resolver: "nightly-2020-01-08"
       stack-yaml: "stack.yaml"
     mac-da-ghc-8.8.1-8.8.1:
       image: "macOS-10.14"
       mode: "--da"
-      resolver: "nightly-2019-09-26"
+      resolver: "nightly-2020-01-08"
       stack-yaml: "stack.yaml"
 
 pool: {vmImage: '$(image)'}

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -21,7 +21,7 @@ library
                      , directory
                      , optparse-applicative
                      , bytestring
-                     , yaml
+                     , yaml >= 0.11.5.0
                      , text
                      , unordered-containers
                      , extra >=1.6

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -22,6 +22,7 @@ library
                      , optparse-applicative
                      , bytestring
                      , yaml
+                     , aeson
                      , text
                      , unordered-containers
                      , extra >=1.6

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -20,6 +20,10 @@ library
                      , containers
                      , directory
                      , optparse-applicative
+                     , bytestring
+                     , yaml
+                     , text
+                     , unordered-containers
                      , extra >=1.6
   hs-source-dirs:    ghc-lib-gen/src
   exposed-modules:   Ghclibgen

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -21,7 +21,7 @@ library
                      , directory
                      , optparse-applicative
                      , bytestring
-                     , yaml >= 0.11.5.0
+                     , yaml
                      , text
                      , unordered-containers
                      , extra >=1.6

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -52,7 +52,39 @@ extra-deps:
 - optparse-applicative-0.15.1.0
 - semigroups-0.19.1
 - transformers-compat-0.6.5
-
+# ghc-lib-gen has recently started depending on yaml
+- assoc-1.0.2
+- base-compat-0.11.1
+- base-orphans-0.8.2
+- integer-logarithms-1.0.3
+- random-1.2.0
+- split-0.2.3.4
+- vector-algorithms-0.8.0.3
+- bifunctors-5.5.7
+- splitmix-0.1.0.1
+- cabal-doctest-1.0.8
+- distributive-0.6.2
+- comonad-5.0.6
+- aeson-1.5.4.0
+- attoparsec-0.13.2.4
+- base-compat-batteries-0.11.1
+- conduit-1.3.2.1
+- data-fix-0.3.0
+- dlist-1.0
+- libyaml-0.1.2
+- mono-traversable-1.0.15.1
+- primitive-0.7.1.0
+- resourcet-1.2.4.2
+- scientific-0.3.6.2
+- strict-0.4
+- tagged-0.8.6
+- th-abstraction-0.3.2.0
+- these-1.1.1.1
+- time-compat-1.9.3
+- unliftio-core-0.2.0.1
+- uuid-types-1.0.3
+- vector-0.12.1.2
+- yaml-0.11.5.0
 flags:
   transformers-compat:
     five-three: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,5 @@
 resolver: lts-16.14 # ghc-8.8.4
 
-extra-deps:
-- yaml-0.11.5.0
-
 ghc-options:
   # try and speed up recompilation on the CI server
   "$everything": -O0 -j

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,8 @@
 resolver: lts-16.14 # ghc-8.8.4
 
+extra-deps:
+- yaml-0.11.5.0
+
 ghc-options:
   # try and speed up recompilation on the CI server
   "$everything": -O0 -j


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git `d7385f7077c6258c2a76ae51b4ea80f6fa9c7015`;
- Remove `happy-1.20.0` from extra-deps in hadrian stack.yaml now https://gitlab.haskell.org/ghc/ghc/-/commit/aaa51dcfdb729f130aeefeaeac15029b62096a74 has landed;
- Rework `applyPatchHadrianStackYaml` to be a little more resilient to the presence/absence of fields.