### PR TITLE
Fix CPP errors

### DIFF
--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -10,13 +10,9 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib(1,0,0)
 #  define GHC_MASTER
-#endif
-
-#if MIN_VERSION_ghc_lib(9,0,1)
+#elif MIN_VERSION_ghc_lib(9,0,0)
 #  define GHC_901
-#endif
-
-#if MIN_VERSION_ghc_lib(8,10,1)
+#elif MIN_VERSION_ghc_lib(8,10,1)
 #  define GHC_8101
 #endif
 
@@ -29,7 +25,7 @@ import "ghc-lib-parser" GHC.Driver.Session
 import "ghc-lib-parser" GHC.Data.StringBuffer
 import "ghc-lib-parser" GHC.Utils.Fingerprint
 import "ghc-lib-parser" GHC.Utils.Outputable
-#  if !defined(GHC_901)
+#  if !defined (GHC_901)
 import "ghc-lib-parser" GHC.Driver.Ppr
 #  endif
 #else
@@ -89,7 +85,7 @@ mkDynFlags filename s = do
   let baseFlags =
         (defaultDynFlags fakeSettings fakeLlvmConfig) {
           ghcLink = NoLink
-#if defined( GHC_MASTER)
+#if defined (GHC_MASTER)
         , backend = NoBackend
 #else
         , hscTarget = HscNothing
@@ -197,7 +193,7 @@ fakeSettings = Settings
 #if defined (GHC_MASTER)
         platformWordSize=PW8
       , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
-#elif defined (GHC_8101)
+#elif defined (GHC_8101) || defined (GHC_901)
         platformWordSize=PW8
       , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
 #else

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -11,13 +11,9 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib_parser(1,0,0)
 #  define GHC_MASTER
-#endif
-
-#if MIN_VERSION_ghc_lib_parser(9,0,1)
+#elif MIN_VERSION_ghc_lib_parser(9,0,0)
 #  define GHC_901
-#endif
-
-#if MIN_VERSION_ghc_lib_parser(8,10,1)
+#elif MIN_VERSION_ghc_lib_parser(8,10,1)
 #  define GHC_8101
 #endif
 
@@ -83,7 +79,7 @@ import Data.Generics.Uniplate.Data
 
 fakeSettings :: Settings
 fakeSettings = Settings
-#if defined (GHC_MASTER) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_901) || defined (GHC_8101)
   { sGhcNameVersion=ghcNameVersion
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
@@ -124,15 +120,15 @@ fakeSettings = Settings
       , platformIsCrossCompiling=False
       , platformLeadingUnderscore=False
       , platformTablesNextToCode=False
-#if !defined(GHC_901)
+#if !defined (GHC_901)
       , platformConstants=platformConstants
 #endif
       ,
 #endif
-#if defined(GHC_MASTER)
+#if defined (GHC_MASTER)
         platformWordSize=PW8
       , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
-#elif defined (GHC_8101)
+#elif defined (GHC_8101) || defined (GHC_901)
         platformWordSize=PW8
       , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
 #else
@@ -144,7 +140,7 @@ fakeSettings = Settings
     platformConstants =
       PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
 
-#if defined (GHC_MASTER) || defined(GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
 fakeLlvmConfig = LlvmConfig [] []
 #else
@@ -198,7 +194,7 @@ analyzeExpr flags (L loc expr) =
                       ++ "`" ++ showSDoc flags (ppr expr) ++ "'")
     _ -> return ()
 
-#if defined(GHC_MASTER) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_901)
 analyzeModule :: DynFlags -> Located HsModule -> ApiAnns -> IO ()
 #else
 analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> ApiAnns -> IO ()
@@ -217,7 +213,7 @@ main = do
           (defaultDynFlags fakeSettings fakeLlvmConfig) file s
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
-#if defined (GHC_MASTER) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_901) || defined (GHC_8101)
             PFailed s ->
               report flags $ snd (getMessages s flags)
 #else
@@ -238,7 +234,7 @@ main = do
         | msg <- pprErrMsgBagWithLoc msgs
         ]
     harvestAnns pst =
-#if defined(GHC_MASTER) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_901)
       ApiAnns
         (Map.fromListWith (++) $ annotations pst)
         Nothing

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -11,15 +11,12 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib_parser(1,0,0)
 #  define GHC_MASTER
-#endif
-
-#if MIN_VERSION_ghc_lib_parser(9,0,1)
+#elif MIN_VERSION_ghc_lib_parser(9,0,0)
 #  define GHC_901
-#endif
-
-#if MIN_VERSION_ghc_lib_parser(8,10,1)
+#elif MIN_VERSION_ghc_lib_parser(8,10,1)
 #  define GHC_8101
 #endif
+
 
 #if defined (GHC_MASTER) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Hs
@@ -138,7 +135,7 @@ fakeSettings = Settings
 #if defined (GHC_MASTER)
         platformWordSize=PW8
       , platformArchOS=ArchOS {archOS_arch=ArchUnknown, archOS_OS=OSUnknown}
-#elif defined (GHC_8101)
+#elif defined (GHC_8101) || defined (GHC_901)
         platformWordSize=PW8
       , platformMini=PlatformMini {platformMini_arch=ArchUnknown, platformMini_os=OSUnknown}
 #else


### PR DESCRIPTION
PR https://github.com/digital-asset/ghc-lib/pull/248 added support for ghc-9.0.1 but messed up the CPP in the tests such that it was wrong but the tests succeeded anyway. This PR fixes the situation.