### PR TITLE
Sync head; ADTs for parser errors

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -57,7 +57,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "235e410f63a4725bbc4466dbdef7d5f661793e84" -- 2020-09-30
+current = "70dc2f09a33a4c3f485d8b63e92a21955643a0b7" -- 2020-10-04
 
 -- Command line argument generators.
 

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -38,6 +38,7 @@ import "ghc-lib-parser" GHC.Data.FastString
 import "ghc-lib-parser" GHC.Utils.Outputable
 #if !defined (GHC_901)
 import "ghc-lib-parser" GHC.Driver.Ppr
+import "ghc-lib-parser" GHC.Parser.Errors.Ppr
 #endif
 import "ghc-lib-parser" GHC.Types.SrcLoc
 import "ghc-lib-parser" GHC.Utils.Panic
@@ -219,18 +220,24 @@ main = do
         parsePragmasIntoDynFlags
           (defaultDynFlags fakeSettings fakeLlvmConfig) file s
       whenJust flags $ \flags ->
-         case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
-#if defined (GHC_MASTER) || defined (GHC_901) || defined (GHC_8101)
-            PFailed s ->
-              report flags $ snd (getMessages s flags)
+         case parse file (flags `gopt_set` Opt_KeepRawTokenStream) s of
+#if defined (GHC_MASTER)
+            PFailed s -> report flags $ fmap pprError (snd (getMessages s))
+#elif defined (GHC_901) || defined (GHC_8101)
+            PFailed s -> report flags $ snd (getMessages s flags)
 #else
-            PFailed _ loc err ->
-              report flags $ unitBag $ mkPlainErrMsg flags loc err
+            PFailed _ loc err -> report flags $ unitBag $ mkPlainErrMsg flags loc err
 #endif
             POk s m -> do
+#if defined (GHC_MASTER)
+              let (wrns, errs) = getMessages s
+              report flags (fmap pprWarning wrns)
+              report flags (fmap pprError errs)
+#else
               let (wrns, errs) = getMessages s flags
               report flags wrns
               report flags errs
+#endif
               when (null errs) $ dumpParseTree flags (stripLocs m)
     _ -> fail "Exactly one file argument required"
   where
@@ -239,15 +246,3 @@ main = do
         [ putStrLn $ showSDoc flags msg
         | msg <- pprErrMsgBagWithLoc msgs
         ]
-    harvestAnns pst =
-#if defined (GHC_MASTER) || defined (GHC_901)
-      ApiAnns
-        (Map.fromListWith (++) $ annotations pst)
-        Nothing
-        (Map.fromList ((realSrcLocSpan (mkRealSrcLoc (fsLit "<no location info>") 0 0), comment_q pst) :annotations_comments pst))
-        []
-#else
-      ( Map.fromListWith (++) $ annotations pst
-      , Map.fromList ((noSrcSpan, comment_q pst) : annotations_comments pst)
-      )
-#endif

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -857,6 +857,16 @@ generateGhcLibParserCabal ghcFlavor = do
 -- | Run Hadrian to build the things that the Cabal files need.
 generatePrerequisites :: GhcFlavor -> IO ()
 generatePrerequisites ghcFlavor = do
+  when (ghcFlavor `elem` [DaGhc881, Ghc881, Ghc882, Ghc883, Ghc884]) (
+    -- Workaround a Windows bug present in at least 8.4.3. See
+    -- http://haskell.1045720.n5.nabble.com/msys-woes-td5898334.html
+    writeFile "./mk/get-win32-tarballs.sh" .
+      replace
+        "$curl_cmd || echo \"Checking repo.msys2.org instead of Haskell.org...\" && $curl_cmd_bnk || {"
+        "$curl_cmd || (echo \"Checking repo.msys2.org instead of Haskell.org...\" && $curl_cmd_bnk) || {"
+      =<< readFile' "./mk/get-win32-tarballs.sh"
+    )
+
   -- If building happy in the next step, the configure it does
   -- requires some versions of alex and happy pre-exist. We make sure
   -- of this in CI.hs.

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -344,6 +344,7 @@ calcParserModules ghcFlavor = do
       -- ghc-lib-parser.
       extraModules =
         [ "GHC.Driver.Config" | ghcFlavor == GhcMaster ] ++
+        [ "GHC.Parser.Errors.Ppr" | ghcFlavor == GhcMaster ] ++
         [ if ghcFlavor `elem` [ GhcMaster, Ghc901 ] then "GHC.Parser.Header" else "HeaderInfo"
         , if ghcFlavor `elem` [ GhcMaster, Ghc901, Ghc8101, Ghc8102 ] then "GHC.Hs.Dump" else "HsDumpAst"
         ]


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git `70dc2f09a33a4c3f485d8b63e92a21955643a0b7`
- Adapt parser error handling on HEAD to https://gitlab.haskell.org/ghc/ghc/-/commit/a5aaceecaa04ce7ea5bade6eb96c0d129109c15a