### PR TITLE
Sync head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,13 @@ dist/
 dist-newstyle/
 .ghc.environment.*
 ghc/
+ghc-lib-parser/
+ghc-lib/
 ghc-master/
 .vscode/
 .stack-work/
 *.hi
+*.o
 .DS_Store
 *.tar.gz
 *_flymake*

--- a/CI.hs
+++ b/CI.hs
@@ -57,7 +57,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "70dc2f09a33a4c3f485d8b63e92a21955643a0b7" -- 2020-10-04
+current = "e63db32c7eb089985a1a7279a0a886a32d70ac0e" -- 2020-11-01
 
 -- Command line argument generators.
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -42,7 +42,11 @@ import "ghc-lib-parser" GHC.Parser.Errors.Ppr
 #  endif
 import "ghc-lib-parser" GHC.Types.SrcLoc
 import "ghc-lib-parser" GHC.Utils.Panic
+#  if defined (GHC_MASTER)
+import "ghc-lib-parser" GHC.Types.SourceError
+#  else
 import "ghc-lib-parser" GHC.Driver.Types
+#  endif
 import "ghc-lib-parser" GHC.Parser.Header
 import "ghc-lib-parser" GHC.Parser.Annotation
 #else

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -42,7 +42,11 @@ import "ghc-lib-parser" GHC.Parser.Errors.Ppr
 #endif
 import "ghc-lib-parser" GHC.Types.SrcLoc
 import "ghc-lib-parser" GHC.Utils.Panic
+#  if defined (GHC_MASTER)
+import "ghc-lib-parser" GHC.Types.SourceError
+#  else
 import "ghc-lib-parser" GHC.Driver.Types
+#  endif
 import "ghc-lib-parser" GHC.Parser.Header
 import "ghc-lib-parser" GHC.Parser.Annotation
 #else


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git `e63db32c7eb089985a1a7279a0a886a32d70ac0e`;
- Adjust for [Split GHC.Driver.Types](https://gitlab.haskell.org/ghc/ghc/-/commit/0e9f6defbdc1f691ff7197b21e68ac16ffa4ab59);
- Local testing suggests we might have trouble with the Windows build again. Specifically, `pacman` is getting 404 errors. Have raised https://github.com/msys2/MSYS2-packages/issues/2225 to track 