### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -57,7 +57,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "e63db32c7eb089985a1a7279a0a886a32d70ac0e" -- 2020-11-01
+current = "6815603f271484766425ff2e37043b78da2d073c" -- 2020-11-23
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -679,7 +679,8 @@ commonBuildDepends ghcFlavor =
   , "process >= 1 && < 1.7"
   , "hpc == 0.6.*"
   ] ++
-  [ "exceptions == 0.10.*" | ghcFlavor `elem` [ GhcMaster, Ghc901]  ]
+  [ "exceptions == 0.10.*" | ghcFlavor `elem` [ GhcMaster, Ghc901]  ] ++
+  [ "parsec" | ghcFlavor == GhcMaster ]
 
 -- | This utility factored out to avoid repetion.
 libBinParserModules :: GhcFlavor -> IO ([Cabal], [Cabal], [String])


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `6815603f271484766425ff2e37043b78da2d073c`;
- New dependency `parsec` required when `--ghc-flavor=ghc-master`.