### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -57,7 +57,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "c647763954717d9853d08ff04eece7f1ddeae15c" -- 2020-12-12
+current = "e9b18a75d5ddf24e5b866fbce17a3648570721af" -- 2020-12-15
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -90,7 +90,10 @@ mkDynFlags filename s = do
 #else
         , hscTarget = HscNothing
 #endif
-#if defined (GHC_MASTER) || defined (GHC_901)
+#if defined (GHC_MASTER)
+        -- Intentionally empty (unit related flags have moved to
+        -- HscEnv).
+#elif defined (GHC_901)
         , unitDatabases = Just []
 #else
         , pkgDatabase = Just []


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `535dae66271af0ce4ab9c0a772614b700bc4c92a`
- Update `mini-compile` in light of [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/d0e8c10d587e4b9984526d0dfcfcb258b75733b8) in which unit related fields are moved from `DynFlags` to `HscEnv`