### PR TITLE
Enable ghc-9.0 as a build compiler

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -446,10 +446,10 @@ applyPatchGhcPrim ghcFlavor = do
       writeFile tysPrim .
           replace
               "bcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName LiftedRep"
-              "\n#if __GLASGOW_HASKELL >= 900\nbcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName LiftedRep\n#else\nbcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName UnliftedRep\n#endif\n" .
+              "\n#if __GLASGOW_HASKELL__ >= 900\nbcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName LiftedRep\n#else\nbcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName UnliftedRep\n#endif\n" .
           replace
               "bcoPrimTyConName              = mkPrimTc (fsLit \"BCO\") bcoPrimTyConKey bcoPrimTyCon"
-              "\n#if __GLASGOW_HASKELL >= 900\nbcoPrimTyConName              = mkPrimTc (fsLit \"BCO\") bcoPrimTyConKey bcoPrimTyCon\n#else\nbcoPrimTyConName              = mkPrimTc (fsLit \"BCO#\") bcoPrimTyConKey bcoPrimTyCon\n#endif\n"
+              "\n#if __GLASGOW_HASKELL__ >= 900\nbcoPrimTyConName              = mkPrimTc (fsLit \"BCO\") bcoPrimTyConKey bcoPrimTyCon\n#else\nbcoPrimTyConName              = mkPrimTc (fsLit \"BCO#\") bcoPrimTyConKey bcoPrimTyCon\n#endif\n"
         =<< readFile' tysPrim
         )
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -446,33 +446,37 @@ applyPatchGhcPrim ghcFlavor = do
       writeFile tysPrim .
           replace
               "bcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName LiftedRep"
-              "bcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName UnliftedRep" .
+              "\n#if __GLASGOW_HASKELL >= 900\nbcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName LiftedRep\n#else\nbcoPrimTyCon = pcPrimTyCon0 bcoPrimTyConName UnliftedRep\n#endif\n" .
           replace
               "bcoPrimTyConName              = mkPrimTc (fsLit \"BCO\") bcoPrimTyConKey bcoPrimTyCon"
-              "bcoPrimTyConName              = mkPrimTc (fsLit \"BCO#\") bcoPrimTyConKey bcoPrimTyCon"
+              "\n#if __GLASGOW_HASKELL >= 900\nbcoPrimTyConName              = mkPrimTc (fsLit \"BCO\") bcoPrimTyConKey bcoPrimTyCon\n#else\nbcoPrimTyConName              = mkPrimTc (fsLit \"BCO#\") bcoPrimTyConKey bcoPrimTyCon\n#endif\n"
         =<< readFile' tysPrim
         )
+
     let createBCO = "libraries/ghci/GHCi/CreateBCO.hs"
     when (ghcFlavor >= Ghc901) (
       writeFile createBCO .
           replace
+              "{-# LANGUAGE RecordWildCards #-}"
+              "{-# LANGUAGE RecordWildCards #-}\n{-# LANGUAGE CPP #-}" .
+          replace
               "do linked_bco <- linkBCO' arr bco"
-              "do BCO bco# <- linkBCO' arr bco" .
+              "\n#if __GLASGOW_HASKELL__ >= 900\n     do linked_bco <- linkBCO' arr bco\n#else\n     do BCO bco# <- linkBCO' arr bco\n#endif" .
           replace
               "then return (HValue (unsafeCoerce linked_bco))\n           else case mkApUpd0# linked_bco of { (# final_bco #) ->"
-              "then return (HValue (unsafeCoerce# bco#))\n           else case mkApUpd0# bco# of { (# final_bco #) ->" .
+              "\n#if __GLASGOW_HASKELL__ >= 900\n           then return (HValue (unsafeCoerce linked_bco))\n           else case mkApUpd0# linked_bco of { (# final_bco #) ->\n#else\n           then return (HValue (unsafeCoerce# bco#))\n           else case mkApUpd0# bco# of { (# final_bco #) ->\n#endif" .
           replace
               "bco <- linkBCO' arr bco\n      writePtrsArrayBCO i bco marr"
-              "BCO bco# <- linkBCO' arr bco\n      writePtrsArrayBCO i bco# marr" .
+              "\n#if __GLASGOW_HASKELL__ >= 900\n      bco <- linkBCO' arr bco\n      writePtrsArrayBCO i bco marr\n#else\n      BCO bco# <- linkBCO' arr bco\n      writePtrsArrayBCO i bco# marr\n#endif" .
           replace
               "writePtrsArrayBCO :: Int -> BCO -> PtrsArr -> IO ()"
-              "writePtrsArrayBCO :: Int -> BCO# -> PtrsArr -> IO ()" .
+              "\n#if __GLASGOW_HASKELL__ >= 900\nwritePtrsArrayBCO :: Int -> BCO -> PtrsArr -> IO ()\n#else\nwritePtrsArrayBCO :: Int -> BCO# -> PtrsArr -> IO ()\n#endif" .
           replace
               "writePtrsArrayMBA :: Int -> MutableByteArray# s -> PtrsArr -> IO ()"
-              "data BCO = BCO BCO#\nwritePtrsArrayMBA :: Int -> MutableByteArray# s -> PtrsArr -> IO ()" .
+              "\n#if __GLASGOW_HASKELL__ >= 900\nwritePtrsArrayMBA :: Int -> MutableByteArray# s -> PtrsArr -> IO ()\n#else\ndata BCO = BCO BCO#\nwritePtrsArrayMBA :: Int -> MutableByteArray# s -> PtrsArr -> IO ()\n#endif" .
           replace
               "newBCO# instrs lits ptrs arity bitmap s"
-              "case newBCO# instrs lits ptrs arity bitmap s of\n    (# s1, bco #) -> (# s1, BCO bco #)"
+              "\n#if __GLASGOW_HASKELL__ >= 900\n  newBCO# instrs lits ptrs arity bitmap s\n#else\n  case newBCO# instrs lits ptrs arity bitmap s of\n    (# s1, bco #) -> (# s1, BCO bco #)\n#endif"
         =<< readFile' createBCO
         )
 
@@ -692,13 +696,9 @@ withCommas ms =
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]
 commonBuildDepends ghcFlavor =
-  [ "ghc-prim > 0.2 && < 0.7"
-  ] ++
-  [ if ghcFlavor < Ghc8101
-    then "base >= 4.11 && < 4.15"
-    else "base >= 4.12 && < 4.15" -- flavor >= 8.10.*
-  ] ++
-  [ "containers >= 0.5 && < 0.7"
+  [ "ghc-prim > 0.2 && < 0.8"
+  , "base >= 4.12 && < 4.16"
+  , "containers >= 0.5 && < 0.7"
   , "bytestring >= 0.9 && < 0.11"
   , "binary == 0.8.*"
   , "filepath >= 1 && < 1.5"


### PR DESCRIPTION
- Updates: `base < 4.16`, `ghc-prim < 0.8`;
- The logic for `applyPatchGhcPrim` needs an update now there is the possibility of `ghc-prim-0.7` (which ships with ghc-9.0.1);
- Fixes https://github.com/digital-asset/ghc-lib/issues/271.

I've hand verified these fixes using Cabal. Unfortunately building with `stack` and resolver `ghc-9.0` is broken preventing me from adding tests in this PR.