### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ddbdec4128f0e6760c8c7a19344f2f2a7a3314bf" -- 2021-02-02
+current = "963e1e9aedf0ee70d4e817640ec9845ed00ce0cf" -- 2021-02-16
 
 -- Command line argument generators.
 

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -19,6 +19,7 @@ module Main (main) where
 
 #if defined (GHC_MASTER)
 import "ghc-lib-parser" GHC.Driver.Config
+import "ghc-lib-parser" GHC.Utils.Logger
 #endif
 #if defined (GHC_MASTER) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Hs
@@ -201,7 +202,11 @@ dumpParseTree :: DynFlags -> Located HsModule -> IO ()
 dumpParseTree :: DynFlags -> Located (HsModule GhcPs) -> IO ()
 #endif
 dumpParseTree flags m =
-#if defined (GHC_MASTER) || defined (GHC_901)
+#if defined(GHC_MASTER)
+  do
+    logger <- initLogger
+    putDumpMsg logger flags (mkDumpStyle alwaysQualify) Opt_D_dump_parsed_ast "" FormatText $ showAstData NoBlankSrcSpan m
+#elif defined(GHC_901)
   dumpAction flags (mkDumpStyle alwaysQualify) (dumpOptionsFromFlag Opt_D_dump_parsed_ast) "" FormatText $ showAstData NoBlankSrcSpan m
 #else
   dumpSDoc flags alwaysQualify Opt_D_dump_parsed_ast "" $ showAstData NoBlankSrcSpan m


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `963e1e9aedf0ee70d4e817640ec9845ed00ce0cf`
- Fix `strip-locs` to account for new logger abstraction in [this MR](https://gitlab.haskell.org/ghc/ghc/-/commit/8e2f85f6b4662676f0d7addaff9bf2c7d751bb63)