### PR TITLE
Fix broken mini-compile test

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "963e1e9aedf0ee70d4e817640ec9845ed00ce0cf" -- 2021-02-16
+current = "dbf8f6fe12db67b96412015a01646ce800f9988a" -- 2021-02-17
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/test/MiniCompileTest.hs
+++ b/examples/mini-compile/test/MiniCompileTest.hs
@@ -82,6 +82,7 @@ data KindRep = KindRepTyConApp TyCon [KindRep]
 
 data TypeLitSort = TypeLitSymbol
                  | TypeLitNat
+                 | TypeLitChar
 
 data TyCon = TyCon Word# Word#           -- Fingerprint
                    Module                -- Module in which this is defined


### PR DESCRIPTION
- Failed to notice but mini-compile test broke recently, this fixes it
- Also take the chance to sync to https://gitlab.haskell.org/ghc/ghc.git @ `dbf8f6fe12db67b96412015a01646ce800f9988a` 