### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "3e082f8ff5ea2f42c5e6430094683b26b5818fb8" -- 2021-03-07
+current = "3e082f8ff5ea2f42c5e6430094683b26b5818fb8" -- 2021-03-10
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,13 +29,14 @@ strategy:
     #  - No Windows 8.8.3 builds are tested (ghc-8.8.3 on Windows
     #    has issues);
     #  - Minimum GHC needed to bootstrap:
-    #      +--------------+------------+
-    #      | GHC flavor   |  version   |
-    #      +==============+============+
-    #      | ghc-8.8.*    |  >= 8.4.4  |
-    #      | ghc-8.10.*   |  >= 8.6.5  | (since 09/29/2019, https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5)
-    #      | ghc-9.0.*    |  >= 8.8.1  | (since 2020/03/31, https://gitlab.haskell.org/ghc/ghc/-/commit/57b888c0e90be7189285a6b078c30b26d092380)
-    #      +--------------+------------+
+    #      +--------------+-------------+
+    #      | GHC flavor   |  version    |
+    #      +==============+=============+
+    #      | ghc-8.8.*    |  >= 8.4.4   |
+    #      | ghc-8.10.*   |  >= 8.6.5   | (since 2019/09/29, https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5)
+    #      | ghc-9.0.*    |  >= 8.8.1   | (since 2020/03/31, https://gitlab.haskell.org/ghc/ghc/-/commit/57b888c0e90be7189285a6b078c30b26d092380)
+    #      | HEAD         |  >= 8.10.1  | (since 2021/03/10, https://gitlab.haskell.org/ghc/ghc/-/commit/0a709dd9876e40c19c934692415c437ac434318c)
+    #      +--------------+-------------+
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -80,7 +80,11 @@ main = do
 mkDynFlags :: String -> String -> IO DynFlags
 mkDynFlags filename s = do
   dirs_to_clean <- newIORef Map.empty
+#if defined (GHC_MASTER)
+       -- Intentionally empty (temp file flags have moved to HscEnv).
+#else
   files_to_clean <- newIORef emptyFilesToClean
+#endif
   next_temp_suffix <- newIORef 0
   let baseFlags =
         (defaultDynFlags fakeSettings fakeLlvmConfig) {
@@ -98,9 +102,13 @@ mkDynFlags filename s = do
 #else
         , pkgDatabase = Just []
 #endif
+#if defined (GHC_MASTER)
+       -- Intentionally empty (temp file flags have moved to HscEnv).
+#else
         , dirsToClean = dirs_to_clean
         , filesToClean = files_to_clean
         , nextTempSuffix = next_temp_suffix
+#endif
 #if defined(DAML_UNIT_IDS)
         , thisInstalledUnitId = toInstalledUnitId (stringToUnitId "daml-prim")
 #else

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-16.14 # ghc-8.8.4
+resolver: lts-17.5 # ghc-8.10.4
 
 ghc-options:
   # try and speed up recompilation on the CI server


### PR DESCRIPTION
- sync to https://gitlab.haskell.org/ghc/ghc.git @ `fcfc66e59c81277c1f7c079ad4e0ccd9a69e1fb6`
- adapt mini-compile to [this commit "DynFlags: move temp file management into HscEnv"](https://gitlab.haskell.org/ghc/ghc/-/commit/daa6363f49df0dceb2c460da500461e564aa9ea2) 
- update `stack.yaml` to lts-17.5 (ghc-8.10.4) because HEAD needs >= 8.10.1 to bootstrap (see [this commit "Require GHC 8.10 as the minimum compiler for bootstrapping"](https://gitlab.haskell.org/ghc/ghc/-/commit/0a709dd9876e40c19c934692415c437ac434318c))