### PR TITLE
Update README; build compiler min version info

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "3e082f8ff5ea2f42c5e6430094683b26b5818fb8" -- 2021-03-10
+current = "545cfefaa88b31daa2cb3519b7561171e7ca51b3" -- 2021-03-15
 
 -- Command line argument generators.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ Building `ghc-lib` is subject to the same minimum version requirements that appl
 | ---------- |:----------:|
 | ghc-8.8.*  | 8.4.4      |
 | ghc-8.10.* | 8.6.5      |
-| ghc-8.11.* | 8.8.1      |
+| ghc-9.0.1  | 8.8.1      |
+| ghc-master | 8.10.1     |
 
 ### How do I use the `ghc-lib`/`ghc-lib-parser` version macros?
 


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `545cfefaa88b31daa2cb3519b7561171e7ca51b3`;
- Update README
  - Note that you need >= ghc-8.8.1 to build ghc-lib-parser-9.*
    - See discussion in https://github.com/digital-asset/ghc-lib/issues/282