### PR TITLE
Better base bounds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,13 +97,13 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-8.8.4  |
+    # | linux   | ghc-master      | ghc-8.10.4 |
     # +---------+-----------------+------------+
-    linux-ghc-master-8.8.4:
+    linux-ghc-master-8.10.4:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
       stack-yaml: "stack.yaml"
-      resolver: "nightly-2020-03-14"
+      resolver: "nightly-2021-03-07"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
@@ -113,17 +113,6 @@ strategy:
     mac-ghc-8.8.4-8.8.4:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-8.8.4"
-      resolver: "nightly-2020-03-14"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-8.10.3      | ghc-8.8.4  |
-    # +---------+-----------------+------------+
-    linux-ghc-8.10.3-8.8.4:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.10.3"
       resolver: "nightly-2020-03-14"
       stack-yaml: "stack.yaml"
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -701,11 +701,37 @@ withCommas ms =
   let ms' = reverse ms in
     reverse (head ms' : map (++ ",") (tail ms'))
 
+-- For each version of GHC, there is a minimum version build compiler
+-- to bootstrap it. For example, for ghc-9.0.1, you need minimum ghc
+-- version ghc-8.8.1 to build it. We want to try to arrange to make a
+-- Cabal build plan impossible for ghc-lib flavor/ build compiler
+-- version combinations that don't make sense. The idea here is to use
+-- the base library version as a proxy for the minimum compiler
+-- version.
+baseBounds :: GhcFlavor -> String
+baseBounds ghcFlavor =
+  case ghcFlavor of
+    -- ghc >= 8.4.4
+    DaGhc881  -> "base >= 4.11 && < 4.16"
+    Ghc881    -> "base >= 4.11 && < 4.16"
+    Ghc882    -> "base >= 4.11 && < 4.16"
+    Ghc883    -> "base >= 4.11 && < 4.16"
+    Ghc884    -> "base >= 4.11 && < 4.16"
+    -- ghc >= 8.6.5
+    Ghc8101   -> "base >= 4.12 && < 4.16"
+    Ghc8102   -> "base >= 4.12 && < 4.16"
+    Ghc8103   -> "base >= 4.12 && < 4.16"
+    Ghc8104   -> "base >= 4.12 && < 4.16"
+    -- ghc >= 8.8.1
+    Ghc901    -> "base >= 4.13 && < 4.16"
+    -- ghc >= 8.10.1
+    GhcMaster -> "base >= 4.14 && < 4.16"
+
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]
 commonBuildDepends ghcFlavor =
   [ "ghc-prim > 0.2 && < 0.8"
-  , "base >= 4.12 && < 4.16"
+  , baseBounds ghcFlavor
   , "containers >= 0.5 && < 0.7"
   , "bytestring >= 0.9 && < 0.11"
   , "binary == 0.8.*"


### PR DESCRIPTION
For each `ghc-lib` "flavor" (e.g. `8.8.*`, `8.10.*`, `9.0*`, ...) there is a minimum version requirement on the ghc build compiler. For example, for `ghc-lib` 8.8 parse trees, the minimum version is 8.4.4, for `ghc-lib` 8.10 parse, trees the minimum version is 8.8.1 and so on like this.

As evidenced on the [Hackage Matrix builder page](https://matrix.hackage.haskell.org/#/package/ghc-lib-parser) page, it would be nice to make Cabal build plans impossible if the minimum required build compiler version isn't met for a given build. See https://github.com/digital-asset/ghc-lib/issues/282#issuecomment-799749806 where @phadej (Oleg Genrus) suggests using base as a proxy for the minimum version. This PR implements that idea.
