### PR TITLE
Restore test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,6 +119,17 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
+    # | linux   | ghc-8.10.3      | ghc-8.8.4  |
+    # +---------+-----------------+------------+
+    linux-ghc-8.10.3-8.8.4:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-8.10.3"
+      resolver: "nightly-2020-03-14"
+      stack-yaml: "stack.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
     # | linux   | da-ghc-8.8.1    | ghc-8.8.1  |
     # | windows | da-ghc-8.8.1    | ghc-8.8.1  |
     # | macOS   | da-ghc-8.8.1    | ghc-8.8.1  |

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -725,7 +725,7 @@ baseBounds ghcFlavor =
     -- ghc >= 8.8.1
     Ghc901    -> "base >= 4.13 && < 4.16"
     -- ghc >= 8.10.1
-    GhcMaster -> "base >= 4.14 && < 4.16"
+    GhcMaster -> "base >= 4.14 && < 4.17"
 
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]


### PR DESCRIPTION
- Restore test (`ghc-flavor=8.10.3` with ghc-8.8.4)
  - As mentioned in https://github.com/digital-asset/ghc-lib/pull/284#discussion_r594917519
  -  Removed mistakenly
 - Tighten upper bounds on base ever so slightly.