### PR TITLE
Sync head: rts bytecode & in-tree annotations

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "3e082f8ff5ea2f42c5e6430094683b26b5818fb8" -- 2021-03-10
+current = "71e609fb1e60cf13035c69c179e3ec722b2e26c4" -- 2021-03-20
 
 -- Command line argument generators.
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -207,13 +207,18 @@ analyzeExpr flags (L loc expr) =
                       ++ "`" ++ showSDoc flags (ppr expr) ++ "'")
     _ -> return ()
 
-#if defined (GHC_MASTER) || defined (GHC_901)
+#if defined (GHC_MASTER)
+analyzeModule :: DynFlags -> Located HsModule -> IO ()
+#elif defined (GHC_901)
 analyzeModule :: DynFlags -> Located HsModule -> ApiAnns -> IO ()
 #else
 analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> ApiAnns -> IO ()
 #endif
-analyzeModule flags (L _ modu) _ =
-  sequence_ [analyzeExpr flags e | e <- universeBi modu]
+analyzeModule flags (L _ modu)
+#if !defined (GHC_MASTER)
+                                _ -- ApiAnns
+#endif
+ = sequence_ [analyzeExpr flags e | e <- universeBi modu]
 
 main :: IO ()
 main = do
@@ -244,7 +249,10 @@ main = do
               report flags errs
 #endif
               when (null errs) $
-               analyzeModule flags m (harvestAnns s)
+                analyzeModule flags m
+#if !defined (GHC_MASTER)
+                                      (harvestAnns s)
+#endif
     _ -> fail "Exactly one file argument required"
   where
 
@@ -258,16 +266,18 @@ main = do
                   pprErrMsgBagWithLoc msgs
 #endif
         ]
+#if !defined(GHC_MASTER)
     harvestAnns pst =
-#if defined (GHC_MASTER) || defined (GHC_901)
+#  if defined (GHC_901)
         ApiAnns {
               apiAnnItems = Map.fromListWith (++) $ annotations pst
             , apiAnnEofPos = Nothing
             , apiAnnComments = Map.fromListWith (++) $ annotations_comments pst
             , apiAnnRogueComments = comment_q pst
             }
-#else
+#  else
       ( Map.fromListWith (++) $ annotations pst
       , Map.fromList ((noSrcSpan, comment_q pst) : annotations_comments pst)
       )
+#  endif
 #endif

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -205,7 +205,7 @@ dumpParseTree flags m =
 #if defined(GHC_MASTER)
   do
     logger <- initLogger
-    putDumpMsg logger flags (mkDumpStyle alwaysQualify) Opt_D_dump_parsed_ast "" FormatText $ showAstData NoBlankSrcSpan m
+    putDumpMsg logger flags (mkDumpStyle alwaysQualify) Opt_D_dump_parsed_ast "" FormatText $ showAstData NoBlankSrcSpan NoBlankApiAnnotations m
 #elif defined(GHC_901)
   dumpAction flags (mkDumpStyle alwaysQualify) (dumpOptionsFromFlag Opt_D_dump_parsed_ast) "" FormatText $ showAstData NoBlankSrcSpan m
 #else

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -33,6 +33,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
       Ghclib -> do
         init ghcFlavor
         applyPatchCmmParseNoImplicitPrelude ghcFlavor
+        applyPatchRtsBytecodes ghcFlavor
         generateGhcLibCabal ghcFlavor
   where
     init :: GhcFlavor -> IO ()


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `3e082f8ff5ea2f42c5e6430094683b26b5818fb8`;
- MR [Generate GHCi bytecode from STG instead of Core and support unboxed tuples and sums](https://gitlab.haskell.org/ghc/ghc/-/commit/1f94e0f7601f8e22fdd81a47f130650265a44196):
  - New instruction codes are added to `includes/rts/Bytecodes.h` and new Haskell code added that uses them:
  - When building`ghc-lib` we use the build compiler RTS:
    - Patch `GHC.ByteCode.Asm` to define these codes if the build compiler is <= 9.0.1;
    - Sufficient to keep `ghc-lib` compiling and its tests passing for now;
- Annotations code affected by MR [GHC Exactprint main commit](https://gitlab.haskell.org/ghc/ghc/-/commit/95275a5f25a2e70b71240d4756109180486af1b1):
  - Adjust the code to stop harvesting any annotations for the time being.
