### PR TITLE
Replace comment '-- *' in Haddock.hs for flavor ghc-9.0

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -10,6 +10,7 @@ module Ghclibgen (
     applyPatchHeapClosures
   , applyPatchHsVersions
   , applyPatchGhcPrim
+  , applyPatchHaddockHs
   , applyPatchRtsBytecodes
   , applyPatchGHCiMessage
   , applyPatchDisableCompileTimeOptimizations
@@ -433,6 +434,22 @@ applyPatchGHCiMessage ghcFlavor =
       =<< readFile' messageHs
   where
       messageHs = "libraries/ghci/GHCi/Message.hs"
+
+-- Users of ghc-lib-parser-9.0.* have reported GHC tripping up on a
+-- comment in this particular source file (see
+-- https://github.com/ndmitchell/hlint/issues/1224 for example). The
+-- comment has been changed in the way we do here on HEAD. We patch it
+-- here for flavor 9.0.
+applyPatchHaddockHs :: GhcFlavor -> IO ()
+applyPatchHaddockHs ghcFlavor = do
+  when (ghcFlavor == Ghc901) (
+    writeFile haddockHs .
+      replace
+        "-- *"
+        "-- -"
+    =<< readFile' haddockHs )
+    where
+      haddockHs = "compiler/GHC/Parser/PostProcess/Haddock.hs"
 
 -- Support for unboxed tuples got landed 03/20/2021
 -- (https://gitlab.haskell.org/ghc/ghc/-/commit/1f94e0f7601f8e22fdd81a47f130650265a44196#4ec156a7b95e9c7a690c99bc79e6e0edf60a51dc)

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -28,6 +28,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         init ghcFlavor
         mangleCSymbols ghcFlavor
         applyPatchStage ghcFlavor
+        applyPatchHaddockHs ghcFlavor
         applyPatchNoMonoLocalBinds ghcFlavor
         generateGhcLibParserCabal ghcFlavor
       Ghclib -> do


### PR DESCRIPTION
[This issue](https://github.com/ndmitchell/hlint/issues/1224) reported first in the Hlint repository and independently [here](https://twitter.com/TechnoEmpress/status/1374686967498178560?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1374686967498178560%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fpublish.twitter.com%2F%3Fquery%3Dhttps3A2F2Ftwitter.com2FTechnoEmpress2Fstatus2F1374686967498178560widget%3DTweet)  on Twitter motivates me to patch `GHC.Parser.PostProcess.Haddock` such that `-- * Stuff` comments are rewritten to `-- - Stuff` where ghc-flavor is ghc-9.0.