### PR TITLE
sync head; ghc-lib depends on rts; fix autoconf (was Sync head; applyPatchGHCiInfoTable)

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -59,7 +59,7 @@ data GhcFlavor = Ghc901
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "71e609fb1e60cf13035c69c179e3ec722b2e26c4" -- 2021-03-20
+current = "efe5fdab01012fae9436f5f8a9c67170ff185243" -- 2021-03-31
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,8 +156,11 @@ steps:
   # macOS
   - bash: |
       /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-      brew install automake
+      brew install autoconf automake pkgconfig m4 libtool gettext
       brew upgrade gmp
+      curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
+      tar -xzf autoconf-2.69.tar.gz
+      (cd autoconf-* && ./configure && make && make install && autoconf --version)
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,12 +155,8 @@ pool: {vmImage: '$(image)'}
 steps:
   # macOS
   - bash: |
-      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-      brew install autoconf automake pkgconfig m4 libtool gettext
-      brew upgrade gmp
-      curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
-      tar -xzf autoconf-2.69.tar.gz
-      (cd autoconf-* && ./configure && make && make install && autoconf --version)
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+      brew install automake
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,11 +156,8 @@ steps:
   # macOS
   - bash: |
       /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-      brew install autoconf automake pkgconfig m4 libtool gettext
+      brew install autoconf@2.13 automake pkgconfig m4 libtool gettext
       brew upgrade gmp
-      curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
-      tar -xzf autoconf-2.69.tar.gz
-      (cd autoconf-* && ./configure && make && make install && autoconf --version)
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -156,8 +156,11 @@ steps:
   # macOS
   - bash: |
       /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-      brew install autoconf@2.13 automake pkgconfig m4 libtool gettext
+      brew install autoconf automake pkgconfig m4 libtool gettext
       brew upgrade gmp
+      curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-2.69.tar.gz
+      tar -xzf autoconf-2.69.tar.gz
+      (cd autoconf-* && ./configure && make && make install && autoconf --version)
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
   - script: |

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -205,7 +205,7 @@ dumpParseTree flags m =
 #if defined(GHC_MASTER)
   do
     logger <- initLogger
-    putDumpMsg logger flags (mkDumpStyle alwaysQualify) Opt_D_dump_parsed_ast "" FormatText $ showAstData NoBlankSrcSpan NoBlankApiAnnotations m
+    putDumpMsg logger flags (mkDumpStyle alwaysQualify) Opt_D_dump_parsed_ast "" FormatText $ showAstData NoBlankSrcSpan NoBlankEpAnnotations m
 #elif defined(GHC_901)
   dumpAction flags (mkDumpStyle alwaysQualify) (dumpOptionsFromFlag Opt_D_dump_parsed_ast) "" FormatText $ showAstData NoBlankSrcSpan m
 #else

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -36,6 +36,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         applyPatchCmmParseNoImplicitPrelude ghcFlavor
         applyPatchRtsBytecodes ghcFlavor
         generateGhcLibCabal ghcFlavor
+        applyPatchGHCiInfoTable ghcFlavor
   where
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -36,7 +36,6 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         applyPatchCmmParseNoImplicitPrelude ghcFlavor
         applyPatchRtsBytecodes ghcFlavor
         generateGhcLibCabal ghcFlavor
-        applyPatchGHCiInfoTable ghcFlavor
   where
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -45,6 +45,9 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor
         applyPatchDisableCompileTimeOptimizations ghcFlavor
+        -- Do this before ./boot && ./configure which occurs in
+        -- 'generatePrerequisites'.
+        applyPatchAclocal ghcFlavor
         -- This invokes 'stack' strictly configured by
         -- 'hadrian/stack.yaml'.
         generatePrerequisites ghcFlavor


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `efe5fdab01012fae9436f5f8a9c67170ff185243`;
- ~~Write a patch for `libraries/ghci/GHCi/InfoTable.hsc`~~
  - Require a definition for `MIN_VERSION_rts` due to [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/e754ff7f178a629a2261cba77a29d9510391aebd);
- Small tweak to `strip-locs` for in-tree exact-print annotations;
- ~~Patch azure on macOS to select autoconf 2.69 over 2.71 which brew is now installing and doesn't work.~~

See https://github.com/digital-asset/ghc-lib/pull/289#issuecomment-812943544 for updated details on what's in this PR.