### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -60,7 +60,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ce706faeef3964116c6e1dd0e6ae2f2e77fde57d" -- 2021-04-02
+current = "6e8e2e0887f12725977feb2a0535f7679e86700f" -- 2021-04-08
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -217,8 +217,11 @@ fakeSettings = Settings
       }
     platformConstants =
        PlatformConstants {
+#if !defined (GHC_MASTER)
          pc_DYNAMIC_BY_DEFAULT=False
-       , pc_WORD_SIZE=8
+       ,
+#endif
+         pc_WORD_SIZE=8
        , pc_STD_HDR_SIZE=1
        , pc_TAG_BITS=3
        , pc_BLOCKS_PER_MBLOCK=252

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -148,7 +148,13 @@ fakeSettings = Settings
       , platformUnregisterised=True
       }
     platformConstants =
-      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
+      PlatformConstants{
+#if !defined (GHC_MASTER)
+          pc_DYNAMIC_BY_DEFAULT=False
+        ,
+#endif
+          pc_WORD_SIZE=8
+    }
 
 #if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -155,7 +155,13 @@ fakeSettings = Settings
       , platformUnregisterised=True
     }
     platformConstants =
-      PlatformConstants{pc_DYNAMIC_BY_DEFAULT=False,pc_WORD_SIZE=8}
+      PlatformConstants{
+#if !defined (GHC_MASTER)
+          pc_DYNAMIC_BY_DEFAULT=False
+        ,
+#endif
+          pc_WORD_SIZE=8
+    }
 
 #if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `6e8e2e0887f12725977feb2a0535f7679e86700f`
- Fix mini-hlint, mini-compile, strip-locs
  - No longer set `pc_DYNAMIC_BY_DEFAULT` field in `PlatformConstants`