### PR TITLE
Revert applyPatchGhcPrelude

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -60,7 +60,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "6974c9e478120f6c4eeb53ebfa935c30cafcdf8e" -- 2021-04-10
+current = "0a8c14bd5a5438b1d042ad279b8ffff1bc867e7e" -- 2021-04-15
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -8,7 +8,6 @@
 
 module Ghclibgen (
     applyPatchHeapClosures
-  , applyPatchGhcPrelude
   , applyPatchAclocal
   , applyPatchHsVersions
   , applyPatchGhcPrim
@@ -689,17 +688,6 @@ applyPatchCmmParseNoImplicitPrelude _ = do
         "import GhcPrelude"
         "import GhcPrelude\nimport qualified Prelude"
     =<< readFile' cmmParse
-
-applyPatchGhcPrelude :: GhcFlavor -> IO ()
-applyPatchGhcPrelude _ = do
-  let ghcPrelude = "compiler/GHC/Prelude.hs"
-  fileExists <- doesFileExist ghcPrelude
-  when fileExists $
-    writeFile ghcPrelude .
-      replace
-        "#if MIN_VERSION_base(4,15,0)"
-        "#if MIN_VERSION_base(4,16,0)"
-    =<< readFile' ghcPrelude
 
 -- [Note : GHC now depends on exceptions package]
 -- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -44,7 +44,6 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor
         applyPatchDisableCompileTimeOptimizations ghcFlavor
-        applyPatchGhcPrelude ghcFlavor
         -- This line must come before 'generatePrerequisites':
         applyPatchAclocal ghcFlavor -- Do before ./boot && ./configure
         -- This invokes 'stack' strictly configured by


### PR DESCRIPTION
- Sync to https://gitlab.haskell.org/ghc/ghc.git @ `0a8c14bd5a5438b1d042ad279b8ffff1bc867e7e1`;
- Remove `applyPatchGhcPrelude` from https://github.com/digital-asset/ghc-lib/pull/292.