### PR TITLE
Update stack-exact resolver to ghc-9.0.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,100 +41,74 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-8.10.3 |
+    # | linux   | ghc-master      | ghc-9.0.1  |
+    # | macOS   | ghc-master      | ghc-9.0.1  |
+    # | linux   | ghc-master      | ghc-8.10.4 |
+    # | macOS   | ghc-master      | ghc-8.10.4 |
     # +---------+-----------------+------------+
-    linux-ghc-master-8.10.3:
+    linux-ghc-master-9.0.1:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-8.10.3"
+      resolver: "ghc-9.0.1"
       stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.2.1       | ghc-8.10.3 |
-    # +---------+-----------------+------------+
-    linux-ghc-9.2.1-8.10.3:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.2.1"
-      resolver: "ghc-8.10.3"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.0.1       | ghc-8.10.3 |
-    # +---------+-----------------+------------+
-    linux-ghc-9.0.1-8.10.3:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.0.1"
-      resolver: "ghc-8.10.3"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-8.10.4      | ghc-8.10.3 |
-    # | macOS   | ghc-8.10.4      | ghc-8.10.3 |
-    # +---------+-----------------+------------+
-    linux-ghc-8.10.4-8.10.3:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.10.4"
-      resolver: "ghc-8.10.3"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-8.10.4-8.10.3:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-8.10.4"
-      resolver: "ghc-8.10.3"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-8.8.4       | ghc-8.10.2 |
-    # | macOS   | ghc-8.8.4       | ghc-8.10.2 |
-    # +---------+-----------------+------------+
-    linux-ghc-8.8.4-8.10.2:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.8.4"
-      resolver: "nightly-2020-12-14"
-      stack-yaml: "stack.yaml"
-    mac-ghc-8.8.4-8.10.2:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-8.8.4"
-      resolver: "nightly-2020-12-14"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-8.10.4 |
-    # +---------+-----------------+------------+
     linux-ghc-master-8.10.4:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
       stack-yaml: "stack.yaml"
       resolver: "nightly-2021-03-07"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
-    # +=========+=================+============+
-    # | macOS   | ghc-8.8.4       | ghc-8.8.4  |
-    # +---------+-----------------+------------+
-    mac-ghc-8.8.4-8.8.4:
+    mac-ghc-master-9.0.1:
       image: "macOS-latest"
-      mode: "--ghc-flavor ghc-8.8.4"
-      resolver: "nightly-2020-03-14"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.0.1"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-master-8.10.4:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "nightly-2021-03-07"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-8.10.3      | ghc-8.8.4  |
+    # | linux   | ghc-9.2.1       | ghc-9.0.1  |
+    # | macOS   | ghc-9.2.1       | ghc-8.10.4 |
+    # +---------+-----------------+------------+
+    linux-ghc-9.2.1-9.0.1:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-9.2.1"
+      resolver: "ghc-9.0.1"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-9.2.1-8.10.4:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-9.2.1"
+      resolver: "ghc-8.10.4"
+      stack-yaml: "stack-exact.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-9.0.1       | ghc-8.10.4 |
+    # | macOS   | ghc-9.0.1       | ghc-8.10.4 |
+    # +---------+-----------------+------------+
+    linux-ghc-9.0.1-8.10.4:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-9.0.1"
+      resolver: "ghc-8.10.4"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-9.0.1-8.10.4:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-9.0.1"
+      resolver: "ghc-8.10.4"
+      stack-yaml: "stack-exact.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-8.10.4      | ghc-8.8.4  |
     # +---------+-----------------+------------+
     linux-ghc-8.10.3-8.8.4:
       image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.10.3"
+      mode: "--ghc-flavor ghc-8.10.4"
       resolver: "nightly-2020-03-14"
       stack-yaml: "stack.yaml"
 
@@ -171,7 +145,7 @@ steps:
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
   - script: |
-      curl -sSL https://get.haskellstack.org/ | sh
+      curl -sSL https://get.haskellstack.org/ | sh -s - -f
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s CI.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s ghc-lib-gen
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/src

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -14,7 +14,7 @@
 # This is a known upstream issue (see
 # https://github.com/commercialhaskell/stack/issues/5134).
 
-resolver: ghc-8.10.3
+resolver: ghc-9.0.1
 
 ghc-options:
   # Try to be quick.
@@ -25,14 +25,14 @@ extra-deps:
 - alex-3.2.6
 - happy-1.20.0
 # Dependencies for ghc-lib examples:
-- hashable-1.3.0.0
-- syb-0.7.1
+- hashable-1.3.1.0
+- syb-0.7.2.1
 - uniplate-1.6.13
 - unordered-containers-0.2.13.0
 # Additional dependencies for CI.hs & ghc-lib-gen:
 - ansi-terminal-0.11
 - ansi-wl-pprint-0.6.9
-- clock-0.8
+- clock-0.8.2
 - colour-2.3.5
 - extra-1.7.9
 - mintty-0.1.2 # Windows specific (but it does no harm).
@@ -47,15 +47,15 @@ extra-deps:
 - random-1.2.0
 - split-0.2.3.4
 - vector-algorithms-0.8.0.4
-- bifunctors-5.5.9
+- bifunctors-5.5.11
 - splitmix-0.1.0.3
 - distributive-0.6.2.1
 - comonad-5.0.8
-- aeson-1.5.4.1
-- attoparsec-0.13.2.4
+- aeson-1.5.6.0
+- attoparsec-0.14.1
 - base-compat-batteries-0.11.2
-- conduit-1.3.4
-- data-fix-0.3.0
+- conduit-1.3.4.1
+- data-fix-0.3.1
 - dlist-1.0
 - libyaml-0.1.2
 - mono-traversable-1.0.15.1
@@ -68,8 +68,8 @@ extra-deps:
 - these-1.1.1.1
 - time-compat-1.9.5
 - unliftio-core-0.2.0.1
-- uuid-types-1.0.3
-- vector-0.12.1.2
+- uuid-types-1.0.5
+- vector-0.12.3.0
 - yaml-0.11.5.0
 - indexed-traversable-0.1.1
 flags:


### PR DESCRIPTION
stack-2.7.1 is released which enables us to incorporate some ghc-9.01 builds. 