### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -60,7 +60,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "fc9546caf3e16db070bfc7bb5523c38595233e26" -- 2021-05-15
+current = "a3665a7aa5db8a77809b8e2246b8cd7eee86935c" -- 2021-05-25
 
 -- Command line argument generators.
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -207,7 +207,11 @@ idNot = mkVarUnqual (fsLit "not")
 
 isNegated :: HsExpr GhcPs -> Bool
 isNegated (HsApp _ (L _ (HsVar _ (L _ id))) _) = id == idNot
+#if defined (GHC_MASTER)
+isNegated (HsPar _ _ (L _ e) _) = isNegated e
+#else
 isNegated (HsPar _ (L _ e)) = isNegated e
+#endif
 isNegated _ = False
 
 #if defined (GHC_MASTER)


### PR DESCRIPTION
- Sync to `fc9546caf3e16db070bfc7bb5523c38595233e26`
- Adapt mini-hlint to `HsPar` now having two `HsToken` values (see https://gitlab.haskell.org/ghc/ghc/-/commit/f8c6fce4a09762adea6009540e523c2b984b2978)