### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -60,7 +60,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "a3665a7aa5db8a77809b8e2246b8cd7eee86935c" -- 2021-05-25
+current = "ce1b8f4208530fe6449506ba22e3a05048f81564" -- 2021-05-27
 
 -- Command line argument generators.
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -19,6 +19,11 @@ module Main (main) where
 #  define GHC_8101
 #endif
 
+#if defined (GHC_MASTER)
+import "ghc-lib-parser" GHC.Driver.Errors.Types
+import "ghc-lib-parser" GHC.Types.Error hiding (getMessages)
+import qualified "ghc-lib-parser" GHC.Types.Error (getMessages)
+#endif
 #if defined (GHC_MASTER) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Driver.Config
 #endif
@@ -257,7 +262,7 @@ main = do
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
 #if defined (GHC_MASTER)
-            PFailed s -> report flags $ fmap mkParserErr (snd (getMessages s))
+            PFailed s -> report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> snd (getMessages s))
 #elif defined (GHC_921)
             PFailed s -> report flags $ fmap pprError (snd (getMessages s))
 #elif defined (GHC_901) || defined (GHC_8101)
@@ -268,8 +273,8 @@ main = do
             POk s m -> do
 #if defined (GHC_MASTER)
               let (wrns, errs) = getMessages s
-              report flags (fmap (mkParserWarn flags) wrns)
-              report flags (fmap mkParserErr errs)
+              report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> wrns)
+              report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> errs)
 #elif defined (GHC_921)
               let (wrns, errs) = getMessages s
               report flags (fmap pprWarning wrns)

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -15,10 +15,15 @@ module Main (main) where
 #  define GHC_921
 #elif MIN_VERSION_ghc_lib_parser(9,0,0)
 #  define GHC_901
-#elif MIN_VERSION_ghc_lib_parser(8,10,1)
+#elif MIN_VERSION_ghc_lib_parser(8,10,0)
 #  define GHC_8101
 #endif
 
+#if defined (GHC_MASTER)
+import "ghc-lib-parser" GHC.Driver.Errors.Types
+import "ghc-lib-parser" GHC.Types.Error hiding (getMessages)
+import qualified "ghc-lib-parser" GHC.Types.Error (getMessages)
+#endif
 #if defined (GHC_MASTER) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Driver.Config
 import "ghc-lib-parser" GHC.Utils.Logger
@@ -244,7 +249,7 @@ main = do
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream) s of
 #if defined (GHC_MASTER)
-            PFailed s -> report flags $ fmap mkParserErr (snd (getMessages s))
+            PFailed s -> report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> (snd (getMessages s)))
 #elif defined (GHC_921)
             PFailed s -> report flags $ fmap pprError (snd (getMessages s))
 #elif defined (GHC_901) || defined (GHC_8101)
@@ -255,8 +260,8 @@ main = do
             POk s m -> do
 #if defined (GHC_MASTER)
               let (wrns, errs) = getMessages s
-              report flags (fmap (mkParserWarn flags) wrns)
-              report flags (fmap mkParserErr errs)
+              report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> wrns)
+              report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> errs)
 #elif defined (GHC_921)
               let (wrns, errs) = getMessages s
               report flags (fmap pprWarning wrns)


### PR DESCRIPTION
- Sync `a3665a7aa5db8a77809b8e2246b8cd7eee86935c`
- Update example error handling adapting to [Support new parser types in GHC](https://gitlab.haskell.org/ghc/ghc/-/commit/cdbce8fc22448837e53515946f16e9571e06f412)