### PR TITLE
Add a mini-hlint expect test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,7 @@ strategy:
     # | macOS   | ghc-master      | ghc-9.0.1  |
     # | linux   | ghc-master      | ghc-8.10.4 |
     # | macOS   | ghc-master      | ghc-8.10.4 |
+    # | windows | ghc-master      | ghc-8.10.4 |
     # +---------+-----------------+------------+
     linux-ghc-master-9.0.1:
       image: "ubuntu-latest"
@@ -63,6 +64,11 @@ strategy:
       stack-yaml: "stack-exact.yaml"
     mac-ghc-master-8.10.4:
       image: "macOS-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "nightly-2021-03-07"
+      stack-yaml: "stack.yaml"
+    windows-ghc-master-8.10.4:
+      image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
       resolver: "nightly-2021-03-07"
       stack-yaml: "stack.yaml"
@@ -145,13 +151,14 @@ steps:
     condition: eq( variables['Agent.OS'], 'Darwin' )
     displayName: Install brew
   - script: |
+      set -e
       curl -sSL https://get.haskellstack.org/ | sh -s - -f
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s CI.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s ghc-lib-gen
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/src
+      curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/strip-locs/src
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
-      set -e
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs
       stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs $(mode)  --stack-yaml $(stack-yaml) --resolver $(resolver)

--- a/examples/mini-hlint/mini-hlint.cabal
+++ b/examples/mini-hlint/mini-hlint.cabal
@@ -18,3 +18,20 @@ executable mini-hlint
                      , uniplate
   default-language:    Haskell2010
   hs-source-dirs:      src
+
+test-suite mini-hlint-test
+  type: exitcode-stdio-1.0
+  main-is:
+      Main.hs
+  hs-source-dirs:
+      test
+  build-depends:
+      base >=4.7 && <5
+    , directory
+    , extra
+    , filepath
+    , optparse-applicative
+    , tagged
+    , tasty
+    , tasty-golden
+    , utf8-string

--- a/examples/mini-hlint/test/Main.hs
+++ b/examples/mini-hlint/test/Main.hs
@@ -1,0 +1,156 @@
+-- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or
+-- its affiliates. All rights reserved.  SPDX-License-Identifier:
+-- (Apache-2.0 OR BSD-3-Clause)
+
+{-# LANGUAGE LambdaCase #-}
+
+import Test.Tasty
+import Test.Tasty.Golden
+import Test.Tasty.Options
+import System.Environment
+import System.Info.Extra
+import System.Directory
+import System.Process.Extra
+import System.FilePath (takeBaseName, replaceExtension)
+import Data.Typeable (Typeable)
+import Data.Tagged
+import Data.Proxy
+import Data.Maybe
+import Data.List.Extra
+import Data.ByteString.Lazy.UTF8
+import Data.Functor
+
+newtype StackYaml = StackYaml (Maybe String)
+  deriving (Eq, Ord, Typeable)
+-- Give as a path relative to the directory containing
+-- mini-hlint.cabal. e.g ../../stack.yaml
+
+newtype Resolver = Resolver (Maybe String)
+  deriving (Eq, Ord, Typeable)
+
+data GhcVersion = DaGhc881
+                | Ghc881
+                | Ghc882
+                | Ghc883
+                | Ghc884
+                | Ghc8101
+                | Ghc8102
+                | Ghc8103
+                | Ghc8104
+                | Ghc901
+                | Ghc921
+                | GhcMaster
+  deriving (Eq, Ord, Typeable)
+
+instance Show GhcVersion where
+  show = showGhcVersion
+
+showGhcVersion :: GhcVersion -> String
+showGhcVersion = \case
+    Ghc921 -> "ghc-9.2.1"
+    Ghc901 -> "ghc-9.0.1"
+    Ghc8101 -> "ghc-8.10.1"
+    Ghc8102 -> "ghc-8.10.2"
+    Ghc8103 -> "ghc-8.10.3"
+    Ghc8104 -> "ghc-8.10.4"
+    Ghc881 -> "ghc-8.8.1"
+    Ghc882 -> "ghc-8.8.2"
+    Ghc883 -> "ghc-8.8.3"
+    Ghc884 -> "ghc-8.8.4"
+    DaGhc881 -> "da-ghc-8.8.1"
+    GhcMaster -> "ghc-master"
+
+newtype GhcFlavor = GhcFlavor GhcVersion
+  deriving(Eq, Ord, Typeable)
+
+readFlavor :: String -> Maybe GhcFlavor
+readFlavor f = GhcFlavor <$>
+  case f of
+    "ghc-9.2.1" -> Just Ghc921
+    "ghc-9.0.1" -> Just Ghc901
+    "ghc-8.10.1" -> Just Ghc8101
+    "ghc-8.10.2" -> Just Ghc8102
+    "ghc-8.10.3" -> Just Ghc8103
+    "ghc-8.10.4" -> Just Ghc8104
+    "ghc-8.8.1" -> Just Ghc881
+    "ghc-8.8.2" -> Just Ghc882
+    "ghc-8.8.3" -> Just Ghc883
+    "ghc-8.8.4" -> Just Ghc884
+    "da-ghc-8.8.1" -> Just DaGhc881
+    "ghc-master" -> Just GhcMaster
+    _ -> Nothing
+
+instance IsOption GhcFlavor where
+  defaultValue = GhcFlavor GhcMaster
+  parseValue = readFlavor
+  optionName = return "ghc-flavor"
+  optionHelp = return "GHC flavor"
+
+instance IsOption StackYaml where
+  defaultValue = StackYaml Nothing
+  parseValue = Just . StackYaml . Just
+  optionName = return "stack-yaml"
+  optionHelp = return "Configuration file"
+
+instance IsOption Resolver where
+  defaultValue = Resolver Nothing
+  parseValue = Just . Resolver . Just
+  optionName = return "resolver"
+  optionHelp = return "Resolver override"
+
+main :: IO ()
+main = do
+  hsFiles <- findByExtension [".hs"] "test"
+
+  defaultMainWithIngredients ings $
+    askOption $ \ config@(StackYaml _) ->
+      askOption $ \ resolver@(Resolver _) ->
+        askOption $ \ flavor@(GhcFlavor _) ->
+          goldenTests config resolver flavor hsFiles
+  where
+    ings =
+      includingOptions
+        [ Option (Proxy :: Proxy StackYaml)
+        , Option (Proxy :: Proxy Resolver)
+        , Option (Proxy :: Proxy GhcFlavor)
+        ]
+      : defaultIngredients
+
+-- Decide if a file is good to test.
+runTest :: GhcVersion -> String -> Bool
+runTest flavor f =
+  (isNothing . stripInfix "Main.hs" $ f) &&
+  ((isNothing . stripInfix "MiniHlintTest_respect_dynamic_pragma.hs" $ f) || (flavor >= Ghc8101)) &&
+  ((isNothing . stripInfix "MiniHlintTest_non_fatal_error.hs" $ f) || (flavor >= Ghc8101))
+
+goldenTests :: StackYaml -> Resolver -> GhcFlavor -> [FilePath] -> TestTree
+goldenTests (StackYaml stackYaml) (Resolver resolver) (GhcFlavor ghcFlavor) hsFiles =
+  testGroup "mini-hlint tests"
+    [ goldenVsString
+         testName
+         expectFile
+         genStringAction
+    | hsFile <- filter (runTest ghcFlavor) hsFiles
+    , let testName = hsFile
+    , let expectFile = replaceExtension hsFile $ (if isWindows then ".windows" else "") ++ ".expect"
+    , let genStringAction = stack $ "--no-terminal exec -- mini-hlint " ++ hsFile
+  ]
+  where
+    stack :: String -> IO ByteString
+    stack action =
+      systemOutput_ ("stack " ++
+        concatMap (<> " ")
+               [ stackYamlOpt stackYaml
+               , stackResolverOpt resolver
+               ] ++
+        action) <&> fromString
+
+    stackYamlOpt :: Maybe String -> String
+    stackYamlOpt = \case
+      Just stackYaml -> "--stack-yaml " ++ stackYaml
+      Nothing -> ""
+
+    stackResolverOpt :: Maybe String -> String
+    stackResolverOpt = \case
+      Just resolver -> "--resolver " ++ resolver
+      Nothing -> ""

--- a/examples/mini-hlint/test/MiniHlintTest.expect
+++ b/examples/mini-hlint/test/MiniHlintTest.expect
@@ -1,0 +1,1 @@
+test/MiniHlintTest.hs:7:18-28 : lint : double negation `not (not x)'

--- a/examples/mini-hlint/test/MiniHlintTest_fail_unknown_pragma.expect
+++ b/examples/mini-hlint/test/MiniHlintTest_fail_unknown_pragma.expect
@@ -1,0 +1,2 @@
+test/MiniHlintTest_fail_unknown_pragma.hs:5:14: error:
+    Unsupported extension: Foo

--- a/examples/mini-hlint/test/MiniHlintTest_fatal_error.expect
+++ b/examples/mini-hlint/test/MiniHlintTest_fatal_error.expect
@@ -1,0 +1,2 @@
+test/MiniHlintTest_fatal_error.hs:11:1: error:
+    parse error on input `{'

--- a/examples/mini-hlint/test/MiniHlintTest_non_fatal_error.expect
+++ b/examples/mini-hlint/test/MiniHlintTest_non_fatal_error.expect
@@ -1,0 +1,3 @@
+test/MiniHlintTest_non_fatal_error.hs:8:18: error:
+    Found `qualified' in postpositive position. 
+    To allow this, enable language extension 'ImportQualifiedPost'

--- a/examples/mini-hlint/test/MiniHlintTest_non_fatal_error.hs
+++ b/examples/mini-hlint/test/MiniHlintTest_non_fatal_error.hs
@@ -1,11 +1,12 @@
 -- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its
 -- affiliates. All rights reserved.  SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
+{-# LANGUAGE NoImportQualifiedPost #-}
 
 module MiniHlintTest_non_fatal_error where
 
 import Data.List qualified
 
--- test/MiniHlintTest_non_fatal_error.hs:6:18: error:
+-- test/MiniHlintTest_non_fatal_error.hs:8:18: error:
 --     Found `qualified' in postpositive position.
 --     To allow this, enable language extension 'ImportQualifiedPost'

--- a/examples/strip-locs/src/Main.hs
+++ b/examples/strip-locs/src/Main.hs
@@ -249,7 +249,7 @@ main = do
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream) s of
 #if defined (GHC_MASTER)
-            PFailed s -> report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> (snd (getMessages s)))
+            PFailed s -> report flags $ GHC.Types.Error.getMessages (GhcPsMessage <$> snd (getMessages s))
 #elif defined (GHC_921)
             PFailed s -> report flags $ fmap pprError (snd (getMessages s))
 #elif defined (GHC_901) || defined (GHC_8101)

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -72,6 +72,16 @@ extra-deps:
 - vector-0.12.3.0
 - yaml-0.11.5.0
 - indexed-traversable-0.1.1
+# Dependencies (not already covered) for golden tests
+- filepath-1.4.2.1
+- tasty-1.4.1
+- tasty-golden-2.3.4
+- utf8-string-1.0.2
+- async-2.2.3
+- temporary-1.3
+- unbounded-delays-0.1.1.1
+- unix-compat-0.5.3
+- wcwidth-0.0.2
 flags:
   transformers-compat:
     five-three: true


### PR DESCRIPTION
- Sync to `6db8a0f76ec45d47060e28bb303e9eef60bdb16b`
- Get a windows `ghc-master` ghc-8.10.4 build going  in CI 
- Add a `--no-checkout` argument to `CI.hs`
  - When it's passed:
    - Don't `rm -rf ghc` on startup
    - Don't `git clone` just refresh existing clone
- Various`mini-hlint` improvements
  - Fix various broken things
  - Write a golden test-suite for it
    - Run that rather than mini-hlint directly in CI
