### PR TITLE
Add support for ghc-8.10.5

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -51,6 +51,7 @@ data GhcFlavor = Ghc921
                | Ghc8102
                | Ghc8103
                | Ghc8104
+               | Ghc8105
                | Ghc881
                | Ghc882
                | Ghc883
@@ -61,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "6db8a0f76ec45d47060e28bb303e9eef60bdb16b" -- 2021-06-01
+current = "5e1a224435fc6ebd34d02566f17fe1eaf5475bab" -- 2021-06-06
 
 -- Command line argument generators.
 
@@ -83,6 +84,7 @@ ghcFlavorOpt = \case
     Ghc8102 -> "--ghc-flavor ghc-8.10.2"
     Ghc8103 -> "--ghc-flavor ghc-8.10.3"
     Ghc8104 -> "--ghc-flavor ghc-8.10.4"
+    Ghc8105 -> "--ghc-flavor ghc-8.10.5"
     Ghc881 -> "--ghc-flavor ghc-8.8.1"
     Ghc882 -> "--ghc-flavor ghc-8.8.2"
     Ghc883 -> "--ghc-flavor ghc-8.8.3"
@@ -114,6 +116,7 @@ genVersionStr = \case
    Ghc8102     -> \day -> "8.10.2." ++ replace "-" "" (showGregorian day)
    Ghc8103     -> \day -> "8.10.3." ++ replace "-" "" (showGregorian day)
    Ghc8104     -> \day -> "8.10.4." ++ replace "-" "" (showGregorian day)
+   Ghc8105     -> \day -> "8.10.5." ++ replace "-" "" (showGregorian day)
    Ghc882      -> \day -> "8.8.2." ++ replace "-" "" (showGregorian day)
    Ghc883      -> \day -> "8.8.3." ++ replace "-" "" (showGregorian day)
    Ghc884      -> \day -> "8.8.4." ++ replace "-" "" (showGregorian day)
@@ -142,6 +145,7 @@ parseOptions = Options
        "ghc-8.10.2" -> Right Ghc8102
        "ghc-8.10.3" -> Right Ghc8103
        "ghc-8.10.4" -> Right Ghc8104
+       "ghc-8.10.5" -> Right Ghc8105
        "ghc-8.8.1" -> Right Ghc881
        "ghc-8.8.2" -> Right Ghc882
        "ghc-8.8.3" -> Right Ghc883
@@ -241,6 +245,7 @@ buildDists
         Ghc8102 -> cmd "cd ghc && git checkout ghc-8.10.2-release"
         Ghc8103 -> cmd "cd ghc && git checkout ghc-8.10.3-release"
         Ghc8104 -> cmd "cd ghc && git checkout ghc-8.10.4-release"
+        Ghc8105 -> cmd "cd ghc && git checkout ghc-8.10.5-release"
         Ghc881 -> cmd "cd ghc && git checkout ghc-8.8.1-release"
         Ghc882 -> cmd "cd ghc && git checkout ghc-8.8.2-release"
         Ghc883 -> cmd "cd ghc && git checkout ghc-8.8.3-release"

--- a/examples/mini-hlint/test/Main.hs
+++ b/examples/mini-hlint/test/Main.hs
@@ -37,6 +37,7 @@ data GhcVersion = DaGhc881
                 | Ghc8102
                 | Ghc8103
                 | Ghc8104
+                | Ghc8105
                 | Ghc901
                 | Ghc921
                 | GhcMaster
@@ -53,6 +54,7 @@ showGhcVersion = \case
     Ghc8102 -> "ghc-8.10.2"
     Ghc8103 -> "ghc-8.10.3"
     Ghc8104 -> "ghc-8.10.4"
+    Ghc8105 -> "ghc-8.10.5"
     Ghc881 -> "ghc-8.8.1"
     Ghc882 -> "ghc-8.8.2"
     Ghc883 -> "ghc-8.8.3"
@@ -72,6 +74,7 @@ readFlavor f = GhcFlavor <$>
     "ghc-8.10.2" -> Just Ghc8102
     "ghc-8.10.3" -> Just Ghc8103
     "ghc-8.10.4" -> Just Ghc8104
+    "ghc-8.10.5" -> Just Ghc8105
     "ghc-8.8.1" -> Just Ghc881
     "ghc-8.8.2" -> Just Ghc882
     "ghc-8.8.3" -> Just Ghc883

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -164,10 +164,11 @@ hadrianGeneratedRoot = \case
   GhcMaster -> stage0Lib
   Ghc921 -> stage0Lib
   Ghc901 -> stage0Lib
-  Ghc8101 -> stage0Lib
-  Ghc8102 -> stage0Lib
-  Ghc8103 -> stage0Lib
+  Ghc8105 -> stage0Lib
   Ghc8104 -> stage0Lib
+  Ghc8103 -> stage0Lib
+  Ghc8102 -> stage0Lib
+  Ghc8101 -> stage0Lib
   _ -> ghcLibGeneratedPath
 
 -- |'dataDir' is the directory cabal looks for data files to install,
@@ -421,6 +422,7 @@ applyPatchDisableCompileTimeOptimizations ghcFlavor =
             Ghc8102 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
             Ghc8103 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
             Ghc8104 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
+            Ghc8105 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
             _ ->         [ "compiler/main/DynFlags.hs", "compiler/hsSyn/HsInstances.hs" ]
     in
       forM_ files $
@@ -799,6 +801,7 @@ baseBounds ghcFlavor =
     Ghc8102   -> "base >= 4.12 && < 4.16"
     Ghc8103   -> "base >= 4.12 && < 4.16"
     Ghc8104   -> "base >= 4.12 && < 4.16"
+    Ghc8105   -> "base >= 4.12 && < 4.16"
 
     Ghc901    -> "base >= 4.13 && < 4.16"
     Ghc921    -> "base >= 4.14 && < 4.17"

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -73,6 +73,7 @@ data GhcFlavor = DaGhc881
                | Ghc8102
                | Ghc8103
                | Ghc8104
+               | Ghc8105
                | Ghc901
                | Ghc921
                | GhcMaster
@@ -92,10 +93,11 @@ readFlavor = eitherReader $ \case
     "ghc-8.10.2" -> Right Ghc8102
     "ghc-8.10.3" -> Right Ghc8103
     "ghc-8.10.4" -> Right Ghc8104
+    "ghc-8.10.5" -> Right Ghc8105
     "ghc-8.8.1" -> Right Ghc881
     "ghc-8.8.2" -> Right Ghc882
     "ghc-8.8.3" -> Right Ghc883
     "ghc-8.8.4" -> Right Ghc884
     "da-ghc-8.8.1" -> Right DaGhc881
     "ghc-master" -> Right GhcMaster
-    flavor -> Left $ "Failed to parse ghc flavor " <> show flavor <> " expected ghc-master, ghc-9.0.1, ghc-8.8.1, ghc-8.8.2, ghc-8.8.3, ghc-8.8.4, da-ghc-8.8.1, ghc-8.10.1, ghc-8.10.2, ghc-8.10.3 or ghc-8.10.4"
+    flavor -> Left $ "Failed to parse ghc flavor " <> show flavor <> " expected ghc-master, ghc-9.0.1, ghc-8.8.1, ghc-8.8.2, ghc-8.8.3, ghc-8.8.4, da-ghc-8.8.1, ghc-8.10.1, ghc-8.10.2, ghc-8.10.3, ghc-8.10.4, ghc-8.10.5, ghc-9.0.1 or ghc-9.2.1"


### PR DESCRIPTION
- Sync to `5e1a224435fc6ebd34d02566f17fe1eaf5475bab`
- Add support for ghc-8.10.5
- In draft until https://github.com/digital-asset/ghc-lib/pull/300 lands (at which point, rebase this on master)