### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "5e1a224435fc6ebd34d02566f17fe1eaf5475bab" -- 2021-06-06
+current = "378c0bba7d132a89dd9c35374b7b4bb5a4730bf7" -- 2021-06-09
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -21,6 +21,9 @@ module Main (main) where
 import "ghc-lib" GHC
 import "ghc-lib" Paths_ghc_lib
 #if defined (GHC_MASTER) ||  defined (GHC_921) || defined (GHC_901)
+#  if defined (GHC_MASTER)
+import "ghc-lib-parser" GHC.Driver.Config.Parser
+#  endif
 import "ghc-lib-parser" GHC.Parser.Header
 import "ghc-lib-parser" GHC.Unit.Module
 import "ghc-lib-parser" GHC.Driver.Session
@@ -127,7 +130,13 @@ mkDynFlags filename s = do
   where
     parsePragmasIntoDynFlags :: String -> String -> DynFlags -> IO DynFlags
     parsePragmasIntoDynFlags fp contents dflags0 = do
-      let opts = getOptions dflags0 (stringToStringBuffer contents) fp
+      let opts = getOptions
+#if defined (GHC_MASTER)
+                 (initParserOpts dflags0)
+#else
+                 dflags0
+#endif
+                 (stringToStringBuffer contents) fp
       (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
       return dflags
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -24,6 +24,9 @@ import "ghc-lib-parser" GHC.Driver.Errors.Types
 import "ghc-lib-parser" GHC.Types.Error hiding (getMessages)
 import qualified "ghc-lib-parser" GHC.Types.Error (getMessages)
 #endif
+#if defined (GHC_MASTER)
+import "ghc-lib-parser" GHC.Driver.Config.Parser
+#endif
 #if defined (GHC_MASTER) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Driver.Ppr
 import "ghc-lib-parser" GHC.Driver.Config
@@ -198,7 +201,13 @@ parse filename flags str =
 parsePragmasIntoDynFlags :: DynFlags -> FilePath -> String -> IO (Maybe DynFlags)
 parsePragmasIntoDynFlags flags filepath str =
   catchErrors $ do
-    let opts = getOptions flags (stringToStringBuffer str) filepath
+    let opts = getOptions
+#if defined (GHC_MASTER)
+                 (initParserOpts flags)
+#else
+                 flags
+#endif
+                 (stringToStringBuffer str) filepath
     (flags, _, _) <- parseDynamicFilePragma flags opts
     return $ Just flags
   where

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -352,6 +352,7 @@ calcParserModules ghcFlavor = do
                    , "GHCi.BinaryArray"
                    , "GHCi.BreakArray"
                    , "GHCi.ResolvedBCO"
+                   , "GHC.Driver.Config.Parser"
                    ]
         ] ++
         [ x | ghcFlavor > Ghc901


### PR DESCRIPTION
- Sync to `5e1a224435fc6ebd34d02566f17fe1eaf5475bab`
- Adapt examples to more `DynFlags` changes [here](https://gitlab.haskell.org/ghc/ghc/-/commit/4dc681c7c0345ee8ae268749d98b419dabf6a3bc) and [here](https://gitlab.haskell.org/ghc/ghc/-/commit/3a90814fdf5800927ef404d46459223b2ba283ce)