### PR TITLE
Disable mini hlint test

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "2d4cdfda6a7f068fe4a1cf586ccb2866b35e0250" -- 2021-07-10
+current = "41d6cfc4d36ba93d82f16f9a83ea69f4e02c3810" -- 2021-07-16
 
 -- Command line argument generators.
 

--- a/examples/mini-hlint/test/MiniHlintTest_fatal_error-ghc-master.expect
+++ b/examples/mini-hlint/test/MiniHlintTest_fatal_error-ghc-master.expect
@@ -1,0 +1,6 @@
+
+test/MiniHlintTest_fatal_error.hs:11:1: error:
+    parse error on input `{'
+   |
+11 | {
+   | ^

--- a/examples/mini-hlint/test/MiniHlintTest_non_fatal_error-ghc-master.expect
+++ b/examples/mini-hlint/test/MiniHlintTest_non_fatal_error-ghc-master.expect
@@ -1,0 +1,7 @@
+
+test/MiniHlintTest_non_fatal_error.hs:8:18: error:
+    Found `qualified' in postpositive position. 
+    Suggested fix: Perhaps you intended to use ImportQualifiedPost
+  |
+8 | import Data.List qualified
+  |                  ^^^^^^^^^


### PR DESCRIPTION
- Depends on https://github.com/digital-asset/ghc-lib/pull/311
  - Rebase this PR on master after the above lands
- Updates to `41d6cfc4d36ba93d82f16f9a83ea69f4e02c3810`
- Disables a mini-hlint expect test (until I work this out: see [why](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6087#note_365110))