### PR TITLE
Sync head; no hpc for ghc-lib-parser build depends

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "41d6cfc4d36ba93d82f16f9a83ea69f4e02c3810" -- 2021-07-16
+current = "a31aa2716b80e617c36db816460faa94ee952b64" -- 2021-07-24
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -825,10 +825,20 @@ commonBuildDepends ghcFlavor =
   , "time >= 1.4 && < 1.10"
   , "transformers == 0.5.*"
   , "process >= 1 && < 1.7"
-  , "hpc == 0.6.*"
   ] ++
   [ "exceptions == 0.10.*" | ghcFlavor >= Ghc901 ] ++
   [ "parsec" | ghcFlavor >= Ghc921 ]
+
+ghcLibParserBuildDepends :: GhcFlavor -> [String]
+ghcLibParserBuildDepends  = commonBuildDepends
+
+ghcLibBuildDepends :: GhcFlavor -> [String]
+ghcLibBuildDepends ghcFlavor =
+  commonBuildDepends ghcFlavor ++
+  [ "rts"
+  , "hpc == 0.6.*"
+  , "ghc-lib-parser"
+  ]
 
 -- | This utility factored out to avoid repetion.
 libBinParserModules :: GhcFlavor -> IO ([Cabal], [Cabal], [String])
@@ -899,10 +909,8 @@ generateGhcLibCabal ghcFlavor = do
         , "        build-depends: unix"
         , "    else"
         , "        build-depends: Win32"
-        , "    build-depends:"
-        , "        rts,"
-        ] ++
-        indent2 (withCommas (commonBuildDepends ghcFlavor ++ [ "ghc-lib-parser" ]))++
+        , "    build-depends:" ] ++
+        indent2 (withCommas (ghcLibBuildDepends ghcFlavor))++
         [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
@@ -980,8 +988,8 @@ generateGhcLibParserCabal ghcFlavor = do
         , "        build-depends: unix"
         , "    else"
         , "        build-depends: Win32"
-        , "    build-depends:"
-        ] ++ indent2 (withCommas (commonBuildDepends ghcFlavor)) ++
+        , "    build-depends:" ] ++
+        indent2 (withCommas (ghcLibParserBuildDepends ghcFlavor)) ++
         [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++


### PR DESCRIPTION
- Sync to `a31aa2716b80e617c36db816460faa94ee952b64`
- Remove `hpc` from ghc-lib-parser `build-depends` (fixes https://github.com/digital-asset/ghc-lib/issues/313) 