### PR TITLE
Sync head; patch InfoTable.hsc

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "a31aa2716b80e617c36db816460faa94ee952b64" -- 2021-07-24
+current = "f27dba8bac144e5a4ac9bbe91833de1870e02c47" -- 2021-07-27
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -36,6 +36,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         applyPatchCmmParseNoImplicitPrelude ghcFlavor
         applyPatchRtsBytecodes ghcFlavor
         generateGhcLibCabal ghcFlavor
+        applyPatchGHCiInfoTable ghcFlavor
   where
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do


### PR DESCRIPTION
- Sync to `f27dba8bac144e5a4ac9bbe91833de1870e02c47`
- Patch `libraries/ghci/GHCi/InfoTable.hsc` to adapt to [rts: Introduce and use ExecPage abstraction](https://gitlab.haskell.org/ghc/ghc/-/commit/0e875c3f1d7373812ddae9962edfc9538465d2ed)