### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "f27dba8bac144e5a4ac9bbe91833de1870e02c47" -- 2021-07-27
+current = "54d6b20192fe6fc244248c7766533a768c591bae" -- 2021-07-29
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -450,7 +450,7 @@ applyPatchGHCiInfoTable ghcFlavor =
            "fillExecBuffer :: CSize -> (Ptr a -> Ptr a -> IO ()) -> IO (Ptr a)\n" <>
          "#endif\n") .
       replace
-        "#error hi"
+        "#error Sorry, rts versions <= 1.0 are not supported"
         (unlines
          [  "foreign import ccall unsafe \"allocateExec\""
           , "  _allocateExec :: CUInt -> Ptr (Ptr a) -> IO (Ptr a)"


### PR DESCRIPTION
- Sync to `54d6b20192fe6fc244248c7766533a768c591bae`
- Adapt to [Improve preprocessor error message](https://gitlab.haskell.org/ghc/ghc/-/commit/54d6b20192fe6fc244248c7766533a768c591bae)