### PR TITLE
Include path changes

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "54d6b20192fe6fc244248c7766533a768c591bae" -- 2021-07-29
+current = "8b9acc4d58f51dcbae73c8226ef876218809fd79" -- 2021-08-09
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -64,8 +64,12 @@ cabalFileLibraries =
 -- | C-preprocessor "include dirs" for 'ghc-lib-parser'.
 ghcLibParserIncludeDirs :: GhcFlavor -> [FilePath]
 ghcLibParserIncludeDirs ghcFlavor =
-  [ "includes" ] ++ -- ghcconfig.h, MachDeps.h, MachRegs.h, CodeGen.Platform.hs
-  [ hadrianGeneratedRoot ghcFlavor, stage0Compiler, "compiler"] ++
+  -- For
+  (if ghcFlavor == GhcMaster
+  then [ "rts/include" ]  -- ghcconfig.h
+  else [ "includes" ]) ++ -- ghcconfig.h, MachDeps.h, MachRegs.h, CodeGen.Platform.hs
+  -- Others
+  [ hadrianGeneratedRoot ghcFlavor, stage0Compiler, "compiler" ] ++
   [ "compiler/utils" | ghcFlavor < Ghc8101 ]
 
 -- Sort by length so the longest paths are at the front. We do this
@@ -251,12 +255,23 @@ fingerprint ghcFlavor = [ stage0Compiler </> "Fingerprint.hs" | ghcFlavor < Ghc8
 -- the 'extraFiles' above as 'extra-source-files'.
 cHeaders :: GhcFlavor -> [String]
 cHeaders ghcFlavor =
-  [ "includes/ghcconfig.h"
-  , "includes/MachDeps.h"
-  , "includes/stg/MachRegs.h"
-  , "includes/CodeGen.Platform.hs"
-  , "compiler/Unique.h"
-  ] ++
+  (if ghcFlavor == GhcMaster
+  then
+    [ "rts/include/ghcconfig.h"
+    , "compiler/MachDeps.h"
+    , "compiler/MachRegs.h"
+    , "compiler/CodeGen.Platform.h"
+    , "compiler/Bytecodes.h"
+    , "compiler/ClosureTypes.h"
+    , "compiler/FunTypes.h"
+    , "compiler/Unique.h"
+    ]
+  else
+    [ "includes/MachDeps.h"
+    , "includes/stg/MachRegs.h"
+    , "includes/CodeGen.Platform.hs"
+    , "compiler/Unique.h"
+    ]) ++
   [ "compiler/HsVersions.h" | ghcFlavor <= Ghc921] ++
   [ f | ghcFlavor < Ghc8101, f <- [ "compiler/nativeGen/NCG.h", "compiler/utils/md5.h"] ]
 


### PR DESCRIPTION
- Requires rebasing on https://github.com/digital-asset/ghc-lib/pull/316 before landing 
- Sync to `8b9acc4d58f51dcbae73c8226ef876218809fd79`
- Adapt to [Move `/includes` to `rst/includes`, sort per package better](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6216)
