### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -62,7 +62,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "8b9acc4d58f51dcbae73c8226ef876218809fd79" -- 2021-08-09
+current = "c367b39e5236b86b4923d826ab0395b33211d30a" -- 2021-08-13
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -172,13 +172,15 @@ fakeSettings = Settings
   where
 #if defined (GHC_MASTER)  || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
     fileSettings = FileSettings {
-        fileSettings_tmpDir="."
-#if defined (GHC_MASTER)  || defined (GHC_921) || defined (GHC_901)
-      , fileSettings_topDir="."
-      , fileSettings_toolDir=Nothing
-      , fileSettings_ghcUsagePath="."
-      , fileSettings_ghciUsagePath="."
-      , fileSettings_globalPackageDatabase="."
+#if !defined (GHC_MASTER)
+        fileSettings_tmpDir=".",
+#endif
+#if !defined (GHC_8101)
+        fileSettings_topDir=".",
+        fileSettings_toolDir=Nothing,
+        fileSettings_ghcUsagePath=".",
+        fileSettings_ghciUsagePath=".",
+        fileSettings_globalPackageDatabase="."
 #endif
       }
 


### PR DESCRIPTION
- Sync to `c65a7ffa7d8962f769bfe1dfbad20e32e1709c20`
- Adapt to [Don't store tmpDir in Settings](https://gitlab.haskell.org/ghc/ghc/-/commit/4f6726779fa3cbbfe97de49b1d26d5a665c74840)
  - That change went in Aug 3 but we didn't notice it broke `mini-compile`
   - We need some CI improvements