### PR TITLE
Add support for ghc-8.10.6

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -52,6 +52,7 @@ data GhcFlavor = Ghc921
                | Ghc8103
                | Ghc8104
                | Ghc8105
+               | Ghc8106
                | Ghc881
                | Ghc882
                | Ghc883
@@ -85,6 +86,7 @@ ghcFlavorOpt = \case
     Ghc8103 -> "--ghc-flavor ghc-8.10.3"
     Ghc8104 -> "--ghc-flavor ghc-8.10.4"
     Ghc8105 -> "--ghc-flavor ghc-8.10.5"
+    Ghc8106 -> "--ghc-flavor ghc-8.10.6"
     Ghc881 -> "--ghc-flavor ghc-8.8.1"
     Ghc882 -> "--ghc-flavor ghc-8.8.2"
     Ghc883 -> "--ghc-flavor ghc-8.8.3"
@@ -117,6 +119,7 @@ genVersionStr = \case
    Ghc8103     -> \day -> "8.10.3." ++ replace "-" "" (showGregorian day)
    Ghc8104     -> \day -> "8.10.4." ++ replace "-" "" (showGregorian day)
    Ghc8105     -> \day -> "8.10.5." ++ replace "-" "" (showGregorian day)
+   Ghc8106     -> \day -> "8.10.6." ++ replace "-" "" (showGregorian day)
    Ghc882      -> \day -> "8.8.2." ++ replace "-" "" (showGregorian day)
    Ghc883      -> \day -> "8.8.3." ++ replace "-" "" (showGregorian day)
    Ghc884      -> \day -> "8.8.4." ++ replace "-" "" (showGregorian day)
@@ -146,6 +149,7 @@ parseOptions = Options
        "ghc-8.10.3" -> Right Ghc8103
        "ghc-8.10.4" -> Right Ghc8104
        "ghc-8.10.5" -> Right Ghc8105
+       "ghc-8.10.6" -> Right Ghc8106
        "ghc-8.8.1" -> Right Ghc881
        "ghc-8.8.2" -> Right Ghc882
        "ghc-8.8.3" -> Right Ghc883
@@ -246,6 +250,7 @@ buildDists
         Ghc8103 -> cmd "cd ghc && git checkout ghc-8.10.3-release"
         Ghc8104 -> cmd "cd ghc && git checkout ghc-8.10.4-release"
         Ghc8105 -> cmd "cd ghc && git checkout ghc-8.10.5-release"
+        Ghc8106 -> cmd "cd ghc && git checkout ghc-8.10.6-release"
         Ghc881 -> cmd "cd ghc && git checkout ghc-8.8.1-release"
         Ghc882 -> cmd "cd ghc && git checkout ghc-8.8.2-release"
         Ghc883 -> cmd "cd ghc && git checkout ghc-8.8.3-release"

--- a/examples/test-utils/src/TestUtils.hs
+++ b/examples/test-utils/src/TestUtils.hs
@@ -30,6 +30,7 @@ data GhcVersion = DaGhc881
                 | Ghc8103
                 | Ghc8104
                 | Ghc8105
+                | Ghc8106
                 | Ghc901
                 | Ghc921
                 | GhcMaster
@@ -47,6 +48,7 @@ showGhcVersion = \case
     Ghc8103 -> "ghc-8.10.3"
     Ghc8104 -> "ghc-8.10.4"
     Ghc8105 -> "ghc-8.10.5"
+    Ghc8106 -> "ghc-8.10.6"
     Ghc881 -> "ghc-8.8.1"
     Ghc882 -> "ghc-8.8.2"
     Ghc883 -> "ghc-8.8.3"
@@ -66,6 +68,7 @@ readFlavor = (GhcFlavor <$>) . \case
     "ghc-8.10.3" -> Just Ghc8103
     "ghc-8.10.4" -> Just Ghc8104
     "ghc-8.10.5" -> Just Ghc8105
+    "ghc-8.10.6" -> Just Ghc8106
     "ghc-8.8.1" -> Just Ghc881
     "ghc-8.8.2" -> Just Ghc882
     "ghc-8.8.3" -> Just Ghc883

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -170,6 +170,7 @@ hadrianGeneratedRoot = \case
   Ghc921 -> stage0Lib
   Ghc901 -> stage0Lib
   Ghc8105 -> stage0Lib
+  Ghc8106 -> stage0Lib
   Ghc8104 -> stage0Lib
   Ghc8103 -> stage0Lib
   Ghc8102 -> stage0Lib
@@ -440,6 +441,7 @@ applyPatchDisableCompileTimeOptimizations ghcFlavor =
             Ghc8103 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
             Ghc8104 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
             Ghc8105 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
+            Ghc8106 ->   [ "compiler/main/DynFlags.hs", "compiler/GHC/Hs.hs" ]
             _ ->         [ "compiler/main/DynFlags.hs", "compiler/hsSyn/HsInstances.hs" ]
     in
       forM_ files $
@@ -902,6 +904,7 @@ baseBounds ghcFlavor =
     Ghc8103   -> "base >= 4.12 && < 4.16"
     Ghc8104   -> "base >= 4.12 && < 4.16"
     Ghc8105   -> "base >= 4.12 && < 4.16"
+    Ghc8106   -> "base >= 4.12 && < 4.16"
 
     Ghc901    -> "base >= 4.13 && < 4.16"
     Ghc921    -> "base >= 4.14 && < 4.17"

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -74,6 +74,7 @@ data GhcFlavor = DaGhc881
                | Ghc8103
                | Ghc8104
                | Ghc8105
+               | Ghc8106
                | Ghc901
                | Ghc921
                | GhcMaster
@@ -94,10 +95,11 @@ readFlavor = eitherReader $ \case
     "ghc-8.10.3" -> Right Ghc8103
     "ghc-8.10.4" -> Right Ghc8104
     "ghc-8.10.5" -> Right Ghc8105
+    "ghc-8.10.6" -> Right Ghc8106
     "ghc-8.8.1" -> Right Ghc881
     "ghc-8.8.2" -> Right Ghc882
     "ghc-8.8.3" -> Right Ghc883
     "ghc-8.8.4" -> Right Ghc884
     "da-ghc-8.8.1" -> Right DaGhc881
     "ghc-master" -> Right GhcMaster
-    flavor -> Left $ "Failed to parse ghc flavor " <> show flavor <> " expected ghc-master, ghc-9.0.1, ghc-8.8.1, ghc-8.8.2, ghc-8.8.3, ghc-8.8.4, da-ghc-8.8.1, ghc-8.10.1, ghc-8.10.2, ghc-8.10.3, ghc-8.10.4, ghc-8.10.5, ghc-9.0.1 or ghc-9.2.1"
+    flavor -> Left $ "Failed to parse ghc flavor " <> show flavor <> " expected ghc-master, ghc-9.0.1, ghc-8.8.1, ghc-8.8.2, ghc-8.8.3, ghc-8.8.4, da-ghc-8.8.1, ghc-8.10.1, ghc-8.10.2, ghc-8.10.3, ghc-8.10.4, ghc-8.10.5, ghc-8.10.6, ghc-9.0.1 or ghc-9.2.1"


### PR DESCRIPTION
- Requires rebasing on https://github.com/digital-asset/ghc-lib/pull/318 once landed
- Adds support for `ghc-flavor = ghc-8.10.6`