### PR TITLE
Sync head

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -63,7 +63,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "c367b39e5236b86b4923d826ab0395b33211d30a" -- 2021-08-13
+current = "ad28ae41206e3a8b483b067a8e3333df445010b6" -- 2021-08-22
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -940,7 +940,8 @@ ghcLibBuildDepends ghcFlavor =
   [ "rts"
   , "hpc == 0.6.*"
   , "ghc-lib-parser"
-  ]
+  ] ++
+  [ "stm" | ghcFlavor > Ghc921]
 
 -- | This utility factored out to avoid repetion.
 libBinParserModules :: GhcFlavor -> IO ([Cabal], [Cabal], [String])


### PR DESCRIPTION
- Sync to `ad28ae41206e3a8b483b067a8e3333df445010b6`
- Add `stm` to `ghc-lib`'s `build-depends` for `ghc > 9.2.1` due to [Driver rework pt3: the upsweep](https://gitlab.haskell.org/ghc/ghc/-/commit/5f0d2dab9be5b0f89d61e9957bb728538b162230)