### PR TITLE
Updates for ghc-9.2.1-rc

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -243,7 +243,7 @@ buildDists
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
     case ghcFlavor of
-        Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-alpha2"
+        Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-rc1"
         Ghc901 -> cmd "cd ghc && git checkout ghc-9.0.1-release"
         Ghc8101 -> cmd "cd ghc && git checkout ghc-8.10.1-release"
         Ghc8102 -> cmd "cd ghc && git checkout ghc-8.10.2-release"

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -155,7 +155,7 @@ fakeSettings = Settings
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-#  if !defined (GHC_MASTER)
+#  if !defined (GHC_MASTER) && !defined (GHC_921)
   , sPlatformConstants=platformConstants
 #  endif
   , sToolSettings=toolSettings
@@ -211,10 +211,10 @@ fakeSettings = Settings
       , platformIsCrossCompiling=False
       , platformLeadingUnderscore=False
       , platformTablesNextToCode=False
-#if defined(GHC_MASTER)
+#if defined(GHC_MASTER) || defined(GHC_921)
       , platform_constants = Nothing
 #endif
-#if !defined(GHC_MASTER) && !defined(GHC_901)
+#if !defined(GHC_MASTER) && !defined(GHC_921) && !defined(GHC_901)
       , platformConstants=platformConstants
 #endif
       ,
@@ -231,7 +231,7 @@ fakeSettings = Settings
 #endif
       , platformUnregisterised=True
       }
-#if !defined (GHC_MASTER)
+#if !defined (GHC_MASTER) && !defined (GHC_921)
     platformConstants =
        PlatformConstants {
          pc_DYNAMIC_BY_DEFAULT=False

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -104,7 +104,7 @@ fakeSettings = Settings
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-#if !defined (GHC_MASTER)
+#if !defined (GHC_MASTER) && !defined (GHC_921)
   , sPlatformConstants=platformConstants
 #endif
   , sToolSettings=toolSettings
@@ -142,10 +142,10 @@ fakeSettings = Settings
       , platformIsCrossCompiling=False
       , platformLeadingUnderscore=False
       , platformTablesNextToCode=False
-#if defined(GHC_MASTER)
+#if defined(GHC_MASTER) || defined(GHC_921)
       , platform_constants = Nothing
 #endif
-#if !defined(GHC_MASTER) && !defined (GHC_901)
+#if !defined(GHC_MASTER) && !defined(GHC_921) && !defined (GHC_901)
       , platformConstants=platformConstants
 #endif
       ,
@@ -162,7 +162,7 @@ fakeSettings = Settings
 #endif
       , platformUnregisterised=True
       }
-#if !defined (GHC_MASTER)
+#if !defined(GHC_MASTER) && !defined(GHC_921)
     platformConstants =
       PlatformConstants{
           pc_DYNAMIC_BY_DEFAULT=False

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -41,6 +41,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
         applyPatchHadrianStackYaml ghcFlavor
+        applyPatchPrelude ghcFlavor
         applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor


### PR DESCRIPTION
`ghc-9.2.1-rc` was dropped today.
- Update the git tag for flavor `ghc-9.2.1`
- Make some minor adjustments resulting from fixes that have been backported.