### PR TITLE
ghc-9.2.1-release

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -64,7 +64,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ef92a0095cee1f623fba1c285c1836e80bf16223" -- 2021-10-01
+current = "98aa29d3fe447cce3407e6864b015892244bb475" -- 2021-10-24
 
 -- Command line argument generators.
 
@@ -247,7 +247,7 @@ buildDists
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
     case ghcFlavor of
-        Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-rc1"
+        Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-release"
         Ghc901 -> cmd "cd ghc && git checkout ghc-9.0.1-release"
         Ghc8101 -> cmd "cd ghc && git checkout ghc-8.10.1-release"
         Ghc8102 -> cmd "cd ghc && git checkout ghc-8.10.2-release"

--- a/examples/mini-compile/mini-compile.cabal
+++ b/examples/mini-compile/mini-compile.cabal
@@ -16,6 +16,8 @@ executable mini-compile
                      , directory
                      , extra
                      , ghc-lib
+-- TODO: investigate. shouldn't be necessary but 9.2.1 fails without
+                     , ghc-lib-parser
   default-language:    Haskell2010
   hs-source-dirs:      src
   if flag(daml-unit-ids)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -928,22 +928,49 @@ baseBounds ghcFlavor =
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]
 commonBuildDepends ghcFlavor =
-  [ "ghc-prim > 0.2 && < 0.8"
-  , baseBounds ghcFlavor
-  , "containers >= 0.5 && < 0.7"
-  , "bytestring >= 0.9 && < 0.11"
-  , "binary == 0.8.*"
-  , "filepath >= 1 && < 1.5"
-  , "directory >= 1 && < 1.4"
-  , "array >= 0.1 && < 0.6"
-  , "deepseq >= 1.4 && < 1.5"
-  , "pretty == 1.1.*"
-  , "time >= 1.4 && < 1.10"
-  , "transformers == 0.5.*"
-  , "process >= 1 && < 1.7"
-  ] ++
-  [ "exceptions == 0.10.*" | ghcFlavor >= Ghc901 ] ++
-  [ "parsec" | ghcFlavor >= Ghc921 ]
+  base ++ specific ++ conditional ++ shared
+  where
+    -- base
+    base =
+      [
+        baseBounds ghcFlavor
+      ]
+    -- bumped in 9.2.1
+    specific =
+      if ghcFlavor >= Ghc921 then
+        [
+          "ghc-prim > 0.2 && < 0.9"
+        , "bytestring >= 0.9 && < 0.12"
+        , "time >= 1.4 && < 1.12"
+        ]
+      else
+        [
+          "ghc-prim > 0.2 && < 0.8"
+        , "bytestring >= 0.9 && < 0.11"
+        , "time >= 1.4 && < 1.10"
+        ]
+    -- added in 9.0.1
+    conditional =
+      if ghcFlavor >= Ghc901 then
+        [
+          "exceptions == 0.10.*"
+        , "parsec"
+        ]
+      else
+        []
+    -- shared for all flavors
+    shared =
+      [
+        "containers >= 0.5 && < 0.7"
+      , "binary == 0.8.*"
+      , "filepath >= 1 && < 1.5"
+      , "directory >= 1 && < 1.4"
+      , "array >= 0.1 && < 0.6"
+      , "deepseq >= 1.4 && < 1.5"
+      , "pretty == 1.1.*"
+      , "transformers == 0.5.*"
+      , "process >= 1 && < 1.7"
+      ]
 
 ghcLibParserBuildDepends :: GhcFlavor -> [String]
 ghcLibParserBuildDepends  = commonBuildDepends


### PR DESCRIPTION
- update the `ghc-flavor 9.2.1` tag to refer to the released version  