### PR TITLE
Better upper bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ Build `ghc-lib` using the [above instructions](#building-ghc-lib)  and upload th
 
 Building `ghc-lib` is subject to the same minimum version requirements that apply to bootstrapping GHC itself. Those requirements are given in the following table.
 
-| Ghc flavor | >= version |
-| ---------- |:----------:|
-| ghc-8.8.*  | 8.4.4      |
-| ghc-8.10.* | 8.6.5      |
-| ghc-9.0.1  | 8.8.1      |
-| ghc-master | 8.10.1     |
+| Ghc flavor | >= version | < version |
+| ---------- |:----------:|:---------:|
+| ghc-8.8.*  | 8.4.4      | 8.10.1    |
+| ghc-8.10.* | 8.6.5      | 9.0.1     |
+| ghc-9.0.1  | 8.8.1      | 9.2.1     |
+| ghc-9.2.1  | 8.10.1     |           |
+| ghc-master | 8.10.1     |           |
 
 ### How do I use the `ghc-lib`/`ghc-lib-parser` version macros?
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ strategy:
     #      | ghc-8.8.*    |  >= 8.4.4   |
     #      | ghc-8.10.*   |  >= 8.6.5   | (since 2019/09/29, https://gitlab.haskell.org/ghc/ghc/commit/24620182abdfcc65a0cfc0e2f3bc391d464d0ad5)
     #      | ghc-9.0.*    |  >= 8.8.1   | (since 2020/03/31, https://gitlab.haskell.org/ghc/ghc/-/commit/57b888c0e90be7189285a6b078c30b26d092380)
-    #      | HEAD         |  >= 8.10.1  | (since 2021/03/10, https://gitlab.haskell.org/ghc/ghc/-/commit/0a709dd9876e40c19c934692415c437ac434318c)
+    #      | >= ghc-9.2.1 |  >= 8.10.1  | (since 2021/03/10, https://gitlab.haskell.org/ghc/ghc/-/commit/0a709dd9876e40c19c934692415c437ac434318c)
     #      +--------------+-------------+
 
     # +---------+-----------------+------------+

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -922,24 +922,25 @@ baseBounds :: GhcFlavor -> String
 baseBounds ghcFlavor =
   case ghcFlavor of
     -- ghc >= 8.4.4
-    DaGhc881  -> "base >= 4.11 && < 4.16"
-    Ghc881    -> "base >= 4.11 && < 4.16"
-    Ghc882    -> "base >= 4.11 && < 4.16"
-    Ghc883    -> "base >= 4.11 && < 4.16"
-    Ghc884    -> "base >= 4.11 && < 4.16"
+    DaGhc881  -> "base >= 4.11 && < 4.14" -- [ghc-8.4.4, ghc-8.10.1)
+    Ghc881    -> "base >= 4.11 && < 4.14"
+    Ghc882    -> "base >= 4.11 && < 4.14"
+    Ghc883    -> "base >= 4.11 && < 4.14"
+    Ghc884    -> "base >= 4.11 && < 4.14"
 
-    Ghc8101   -> "base >= 4.12 && < 4.17"
-    Ghc8102   -> "base >= 4.12 && < 4.17"
-    Ghc8103   -> "base >= 4.12 && < 4.17"
-    Ghc8104   -> "base >= 4.12 && < 4.17"
-    Ghc8105   -> "base >= 4.12 && < 4.17"
-    Ghc8106   -> "base >= 4.12 && < 4.17"
-    Ghc8107   -> "base >= 4.12 && < 4.17"
+    Ghc8101   -> "base >= 4.12 && < 4.15" -- [ghc-8.6.5, ghc-9.0.1)
+    Ghc8102   -> "base >= 4.12 && < 4.15"
+    Ghc8103   -> "base >= 4.12 && < 4.15"
+    Ghc8104   -> "base >= 4.12 && < 4.15"
+    Ghc8105   -> "base >= 4.12 && < 4.15"
+    Ghc8106   -> "base >= 4.12 && < 4.15"
+    Ghc8107   -> "base >= 4.12 && < 4.15"
 
-    Ghc901    -> "base >= 4.13 && < 4.17"
-    Ghc921    -> "base >= 4.14 && < 4.17"
+    Ghc901    -> "base >= 4.13 && < 4.16" -- [ghc-8.8.1, ghc-9.2.1)
 
-    GhcMaster -> "base >= 4.14 && < 4.17"
+    Ghc921    -> "base >= 4.14 && < 4.17" -- [ghc-8.10.1, ...)
+
+    GhcMaster -> "base >= 4.14 && < 4.17" -- [ghc-8.10.1, ...)
 
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]


### PR DESCRIPTION
now we are clear that in general later versions of ghc can't compile earlier versions, this pr tightens base upper bounds with the intent of preventing doomed to fail build plans. this might have saved some time in issue https://github.com/digital-asset/ghc-lib/issues/332. update the README with the new bounds info 