### PR TITLE
remove applyPatchPrelude

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -64,7 +64,7 @@ data GhcFlavor = Ghc921
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "aed98ddaf72cc38fb570d8415cac5de9d8888818" -- 2021-11-19
+current = "9dcb2ad15df54e209cfae3dd1f51cf8e8d6c69d5" -- 2021-11-24
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -13,7 +13,6 @@
 module Ghclibgen (
     applyPatchHeapClosures
   , applyPatchAclocal
-  , applyPatchPrelude
   , applyPatchHsVersions
   , applyPatchGhcPrim
   , applyPatchHaddockHs
@@ -395,15 +394,6 @@ calcParserModules ghcFlavor = do
         , if ghcFlavor >= Ghc8101 then "GHC.Hs.Dump" else "HsDumpAst"
         ]
   return $ nubSort (modules ++ extraModules)
-
-applyPatchPrelude :: GhcFlavor -> IO ()
-applyPatchPrelude ghcFlavor = do
-  when (ghcFlavor == Ghc921) $ do
-    writeFile "compiler/GHC/Prelude.hs" .
-      replace
-        "#if MIN_VERSION_base(4,15,0)"
-        "#if MIN_VERSION_base(4,16,0)"
-    =<< readFile' "compiler/GHC/Prelude.hs"
 
 -- Avoid duplicate symbols with HSghc-heap (see issue
 -- https://github.com/digital-asset/ghc-lib/issues/210).

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -35,13 +35,12 @@ ghclibgen (GhclibgenOpts root target ghcFlavor) =
         init ghcFlavor
         applyPatchCmmParseNoImplicitPrelude ghcFlavor
         applyPatchRtsBytecodes ghcFlavor
-        generateGhcLibCabal ghcFlavor
         applyPatchGHCiInfoTable ghcFlavor
+        generateGhcLibCabal ghcFlavor
   where
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
         applyPatchHadrianStackYaml ghcFlavor
-        applyPatchPrelude ghcFlavor
         applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor


### PR DESCRIPTION
the fix for bits bounds was backported to 9.2.1 in `1571772e37b587495dea7f2e0c575c70141027d8` making `applyPatchPrelude` a no-op. remove.