### PR TITLE
Support building DA 8.8.1 ghc lib with GHC 9.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,9 +175,6 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
   - bash: |
-      stack exec -- pacman -Sy --noconfirm msys2-keyring
-    condition: eq(variables['Agent.OS'], 'Windows_NT')
-  - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,6 +174,7 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/src
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
+      stack exec -- pacman -Sy msys2-keyring
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,7 +175,7 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
   - bash: |
-      stack exec -- pacman -Sy --noconfirm msys2-keyring
+      stack exec -- pacman -Syu --noconfirm
     condition: eq(variables['Agent.OS'], 'Windows_NT')
   - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,7 +175,7 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
   - bash: |
-      stack exec -- pacman -Sy msys2-keyring
+      stack exec -- pacman -Sy --noconfirm msys2-keyring
     condition: eq(variables['Agent.OS'], 'Windows_NT')
   - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -175,6 +175,9 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
   - bash: |
+      stack exec -- pacman -Sy --noconfirm msys2-keyring
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+  - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,7 +174,10 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/src
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-hlint/test/Main.hs
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
+  - bash: |
       stack exec -- pacman -Sy msys2-keyring
+    condition: eq(variables['Agent.OS'], 'Windows')
+  - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null
       stack exec --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative ghc -- -package extra -package optparse-applicative -Wall -Wno-name-shadowing -Werror -c CI.hs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
   - bash: |
       stack exec -- pacman -Sy msys2-keyring
-    condition: eq(variables['Agent.OS'], 'Windows')
+    condition: eq(variables['Agent.OS'], Windows_NT')
   - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -176,7 +176,7 @@ steps:
       curl -sSL https://raw.github.com/ndmitchell/hlint/master/misc/travis.sh | sh -s examples/mini-compile/src
   - bash: |
       stack exec -- pacman -Sy msys2-keyring
-    condition: eq(variables['Agent.OS'], Windows_NT')
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
   - bash: |
       stack setup --stack-yaml $(stack-yaml) --resolver $(resolver) > /dev/null
       stack install --stack-yaml $(stack-yaml) --resolver $(resolver) alex happy > /dev/null

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ strategy:
     windows-ghc-master-8.10.7:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "lts-18.16"
+      resolver: "lts-18.23"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.5 # ghc-8.10.4
+resolver: lts-18.23 # ghc-8.10.7
 
 ghc-options:
   # try and speed up recompilation on the CI server

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.23 # ghc-8.10.7
+resolver: lts-17.5 # ghc-8.10.4
 
 ghc-options:
   # try and speed up recompilation on the CI server


### PR DESCRIPTION
We need to drop references to the RTS since it has changed in
incompatible ways.