### PR TITLE
update to ghc-9.2.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,18 +41,18 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.2.1  |
-    # | macOS   | ghc-master      | ghc-9.2.1  |
+    # | linux   | ghc-master      | ghc-9.2.2  |
+    # | macOS   | ghc-master      | ghc-9.2.2  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.2.1:
+    linux-ghc-master-9.2.2:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.2.1"
+      resolver: "ghc-9.2.2"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.2.1:
+    mac-ghc-master-9.2.2:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.2.1"
+      resolver: "ghc-9.2.2"
       stack-yaml: "stack-exact.yaml"
 
     # just can't get a build-plan at this time. issues with extra,

--- a/examples/mini-hlint/test/Main.hs
+++ b/examples/mini-hlint/test/Main.hs
@@ -49,7 +49,7 @@ goldenTests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFla
   -- to 't'. E.g. at this time on master, there's this example: 'Found
   -- `qualified' in postpositive position. '
   case (yaml, resolver) of
-    -- Running ghc-9.2.1 with stack 2.7.3 produces
+    -- Running ghc-9.2.1(ghc-9.2.2) with stack 2.7.3(2.7.5) produces
     --   "Stack has not been tested with GHC versions above 9.0, and using 9.2.1, this may fail"
     --   "Stack has not been tested with Cabal versions above 3.4, but version 3.6.0.0 was found, this may fail"
     -- on stderr which being unexpected, causes the golden tests to fail.
@@ -59,7 +59,7 @@ goldenTests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFla
     -- it. So, for now just don't run this test.
     (Just "../../stack-exact.yaml", Nothing) -> -- implicit resolver 'ghc-9.2.1'
       testGroup "mini-hlint tests" []
-    (_, Just "ghc-9.2.1") ->  -- explicit resolver 'ghc-9.2.1'
+    (_, Just ghc) | ghc `elem` ["ghc-9.2.1", "ghc-9.2.2"] ->  -- explicit resolvers
       testGroup "mini-hlint tests" []
     (_, _) ->
       testGroup "mini-hlint tests"

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -14,7 +14,7 @@
 # This is a known upstream issue (see
 # https://github.com/commercialhaskell/stack/issues/5134).
 
-resolver: ghc-9.0.1
+resolver: ghc-9.2.2
 
 ghc-options:
   # Try to be quick.
@@ -41,6 +41,7 @@ extra-deps:
 - mintty-0.1.3 # windows specific (but it does no harm).
 - Win32-2.13.1.0 # new mintty dependency
 - optparse-applicative-0.16.1.0
+- process-1.6.14.0
 - semigroups-0.19.2
 - transformers-compat-0.7.1
 # ghc-lib-gen has recently started depending on yaml
@@ -59,7 +60,7 @@ extra-deps:
 - splitmix-0.1.0.4
 - distributive-0.6.2.1
 - comonad-5.0.8
-- aeson-2.0.2.0
+- aeson-2.0.3.0
 - attoparsec-0.14.2
 - conduit-1.3.4.2
 - data-fix-0.3.2
@@ -75,7 +76,7 @@ extra-deps:
 - semigroupoids-5.3.6
 - strict-0.4.0.1
 - tagged-0.8.6.1
-- text-short-0.1.4
+- text-short-0.1.5
 - th-abstraction-0.4.3.0
 - these-1.1.1.1
 - time-compat-1.9.6.1
@@ -84,8 +85,8 @@ extra-deps:
 - vector-0.12.3.1
 - yaml-0.11.7.0
 - witherable-0.4.2
+- QuickCheck-2.14.2
 # Dependencies (not already covered) for golden tests
-- filepath-1.4.2.1
 - tasty-1.4.2
 - tasty-golden-2.3.4
 - utf8-string-1.0.2


### PR DESCRIPTION
in `stack-exact.yaml`, make the default `resolver: ghc-9.2.2` and go from CI testing ghc-9.2.1 to ghc-9.2.2 