### PR TITLE
add support for ghc-9.4.1

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -47,7 +47,8 @@ data StackOptions = StackOptions
     , ghcOptions :: Maybe String -- If 'Just _', pass '--ghc-options="xxx"' to 'stack build' (for ghc verbose, try 'v3').
     } deriving (Show)
 
-data GhcFlavor = Ghc922
+data GhcFlavor = Ghc941
+               | Ghc922
                | Ghc921
                | Ghc901
                | Ghc902
@@ -84,6 +85,7 @@ stackResolverOpt = \case
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
+    Ghc941 -> "--ghc-flavor ghc-9.4.1"
     Ghc922 -> "--ghc-flavor ghc-9.2.2"
     Ghc921 -> "--ghc-flavor ghc-9.2.1"
     Ghc901 -> "--ghc-flavor ghc-9.0.1"
@@ -131,6 +133,7 @@ genVersionStr flavor suffix =
     base = case flavor of
       Da {}       -> "8.8.1"
       GhcMaster _ -> "0"
+      Ghc941      -> "9.4.1"
       Ghc922      -> "9.2.2"
       Ghc921      -> "9.2.1"
       Ghc901      -> "9.0.1"
@@ -170,6 +173,7 @@ parseOptions = Options
  where
    readFlavor :: Opts.ReadM GhcFlavor
    readFlavor = Opts.eitherReader $ \case
+       "ghc-9.4.1" -> Right Ghc941
        "ghc-9.2.2" -> Right Ghc922
        "ghc-9.2.1" -> Right Ghc921
        "ghc-9.0.1" -> Right Ghc901
@@ -275,6 +279,7 @@ buildDists
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
     case ghcFlavor of
+        Ghc941 -> cmd "cd ghc && git checkout ghc-9.4"
         Ghc922 -> cmd "cd ghc && git checkout ghc-9.2.2-release"
         Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-release"
         Ghc901 -> cmd "cd ghc && git checkout ghc-9.0.1-release"

--- a/CI.hs
+++ b/CI.hs
@@ -68,7 +68,7 @@ data GhcFlavor = Ghc922
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "e58d5eeb90fb0c35ff08d8d9f752eab74fc9889e" -- 2022-04-08
+current = "a7053a6c04496fa26a62bb3824ccc9664909a6ec" -- 2022-05-01
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,13 +55,30 @@ strategy:
       resolver: "ghc-9.2.2"
       stack-yaml: "stack-exact.yaml"
 
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavour | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-9.4.1       | ghc-9.2.2  |
+    # | macOS   | ghc-9.4.1       | ghc-9.2.2  |
+    # +---------+-----------------+------------+
+    linux-ghc-9.4.1-9.2.2:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-9.4.1"
+      resolver: "ghc-9.2.2"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-9.4.1-9.2.2:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-9.4.1"
+      resolver: "ghc-9.2.2"
+      stack-yaml: "stack-exact.yaml"
+
     # just can't get a build-plan at this time. issues with extra,
     # directory, process & time
 
-    # windows-ghc-master-9.2.1:
+    # windows-ghc-master-9.2.2:
     #   image: "windows-latest"
     #   mode: "--ghc-flavor ghc-master"
-    #   resolver: "ghc-9.2.1"
+    #   resolver: "ghc-9.2.2"
     #   stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -10,6 +10,8 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib(1,0,0)
 #  define GHC_MASTER
+#elif MIN_VERSION_ghc_lib(9,4,1)
+#  define GHC_941
 #elif MIN_VERSION_ghc_lib(9,2,1)
 #  define GHC_921
 #elif MIN_VERSION_ghc_lib(9,0,0)
@@ -32,8 +34,8 @@ module Main (main) where
 
 import "ghc-lib" GHC
 import "ghc-lib" Paths_ghc_lib
-#if defined (GHC_MASTER) ||  defined (GHC_921) || defined (GHC_901)
-#  if defined (GHC_MASTER)
+#if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#  if defined (GHC_MASTER) || defined (GHC_941)
 import GHC_LIB_PARSER_PKG GHC.Driver.Config.Parser
 #  endif
 import GHC_LIB_PARSER_PKG GHC.Parser.Header
@@ -53,14 +55,14 @@ import GHC_LIB_PARSER_PKG StringBuffer
 import GHC_LIB_PARSER_PKG Fingerprint
 import GHC_LIB_PARSER_PKG Outputable
 #endif
-#if defined (GHC_MASTER)  || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 import GHC_LIB_PARSER_PKG GHC.Settings
 import GHC_LIB_PARSER_PKG GHC.Settings.Config
 #elif defined (GHC_8101)
 import GHC_LIB_PARSER_PKG Config
 import GHC_LIB_PARSER_PKG ToolSettings
 #endif
-#if defined (GHC_MASTER) ||  defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 import GHC_LIB_PARSER_PKG GHC.Platform
 #else
 import GHC_LIB_PARSER_PKG Config
@@ -97,7 +99,7 @@ main = do
 mkDynFlags :: String -> String -> IO DynFlags
 mkDynFlags filename s = do
   dirs_to_clean <- newIORef Map.empty
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
        -- Intentionally empty (temp file flags have moved to HscEnv).
 #else
   files_to_clean <- newIORef emptyFilesToClean
@@ -106,12 +108,12 @@ mkDynFlags filename s = do
   let baseFlags =
         (defaultDynFlags fakeSettings fakeLlvmConfig) {
           ghcLink = NoLink
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
         , backend = NoBackend
 #else
         , hscTarget = HscNothing
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
         -- Intentionally empty (unit related flags have moved to
         -- HscEnv).
 #elif defined (GHC_901)
@@ -119,7 +121,7 @@ mkDynFlags filename s = do
 #else
         , pkgDatabase = Just []
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
        -- Intentionally empty (temp file flags have moved to HscEnv).
 #else
         , dirsToClean = dirs_to_clean
@@ -129,7 +131,7 @@ mkDynFlags filename s = do
 #if defined(DAML_UNIT_IDS)
         , thisInstalledUnitId = toInstalledUnitId (stringToUnitId "daml-prim")
 #else
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
         , homeUnitId_ = toUnitId (stringToUnit "ghc-prim")
 #elif defined (GHC_901)
         , homeUnitId = toUnitId (stringToUnit "ghc-prim")
@@ -142,7 +144,7 @@ mkDynFlags filename s = do
   where
     parsePragmasIntoDynFlags :: String -> String -> DynFlags -> IO DynFlags
     parsePragmasIntoDynFlags filepath contents dflags0 = do
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
       let (_, opts) = getOptions (initParserOpts dflags0)
                         (stringToStringBuffer contents) filepath
 #else
@@ -151,7 +153,7 @@ mkDynFlags filename s = do
       (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
       return dflags
 
-#if defined (GHC_MASTER)  || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
 fakeLlvmConfig = LlvmConfig [] []
 #else
@@ -161,12 +163,12 @@ fakeLlvmConfig = ([], [])
 
 fakeSettings :: Settings
 fakeSettings = Settings
-#if defined (GHC_MASTER) ||  defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
   { sGhcNameVersion=ghcNameVersion
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-#  if !defined (GHC_MASTER) && !defined (GHC_921)
+#  if !defined (GHC_MASTER) && !defined(GHC_941) && !defined (GHC_921)
   , sPlatformConstants=platformConstants
 #  endif
   , sToolSettings=toolSettings
@@ -181,12 +183,12 @@ fakeSettings = Settings
   }
 #endif
   where
-#if defined (GHC_MASTER)  || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
     fileSettings = FileSettings {
 #if defined (GHC_8101)
         fileSettings_tmpDir="."
 #else
-#if !defined(GHC_MASTER)
+#if !defined(GHC_MASTER) && !defined(GHC_941)
         fileSettings_tmpDir=".",
 #endif
        fileSettings_topDir=".",
@@ -201,7 +203,7 @@ fakeSettings = Settings
         toolSettings_opt_P_fingerprint=fingerprint0
       }
     platformMisc = PlatformMisc {
-#if !defined (GHC_MASTER)  && !defined (GHC_921) && !defined (GHC_901)
+#if !defined (GHC_MASTER) && !defined(GHC_941) && !defined (GHC_921) && !defined (GHC_901)
         platformMisc_integerLibraryType=IntegerSimple
 #endif
       }
@@ -212,7 +214,7 @@ fakeSettings = Settings
       }
 #endif
     platform =
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
       genericPlatform
 #else
       Platform{
@@ -248,7 +250,7 @@ fakeSettings = Settings
       , platformUnregisterised=True
       }
 #endif
-#if !defined (GHC_MASTER) && !defined (GHC_921)
+#if !defined (GHC_MASTER) && !defined(GHC_941) && !defined (GHC_921)
     platformConstants =
        PlatformConstants {
          pc_DYNAMIC_BY_DEFAULT=False

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -11,6 +11,8 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib_parser(1,0,0)
 #  define GHC_MASTER
+#elif MIN_VERSION_ghc_lib_parser(9,4,0)
+#  define GHC_941
 #elif MIN_VERSION_ghc_lib_parser(9,2,0)
 #  define GHC_921
 #elif MIN_VERSION_ghc_lib_parser(9,0,0)
@@ -19,26 +21,26 @@ module Main (main) where
 #  define GHC_8101
 #endif
 
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
 import "ghc-lib-parser" GHC.Driver.Config.Diagnostic
 import "ghc-lib-parser" GHC.Utils.Logger
 import "ghc-lib-parser" GHC.Driver.Errors
 import "ghc-lib-parser" GHC.Driver.Errors.Types
 import "ghc-lib-parser" GHC.Types.Error
 #endif
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
 import "ghc-lib-parser" GHC.Driver.Config.Parser
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Driver.Ppr
 import "ghc-lib-parser" GHC.Driver.Config
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Hs
 #else
 import "ghc-lib-parser" HsSyn
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 import "ghc-lib-parser" GHC.Settings.Config
 import "ghc-lib-parser" GHC.Driver.Session
 import "ghc-lib-parser" GHC.Data.StringBuffer
@@ -54,7 +56,7 @@ import "ghc-lib-parser" GHC.Parser.Errors.Ppr
 #  endif
 import "ghc-lib-parser" GHC.Types.SrcLoc
 import "ghc-lib-parser" GHC.Utils.Panic
-#  if defined (GHC_MASTER) || defined (GHC_921)
+#  if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Types.SourceError
 #  else
 import "ghc-lib-parser" GHC.Driver.Types
@@ -78,12 +80,12 @@ import "ghc-lib-parser" HscTypes
 import "ghc-lib-parser" HeaderInfo
 import "ghc-lib-parser" ApiAnnotation
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 import "ghc-lib-parser" GHC.Settings
 #elif defined (GHC_8101)
 import "ghc-lib-parser" ToolSettings
 #endif
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Platform
 #else
 import "ghc-lib-parser" Bag
@@ -99,12 +101,12 @@ import Data.Generics.Uniplate.Data
 
 fakeSettings :: Settings
 fakeSettings = Settings
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
   { sGhcNameVersion=ghcNameVersion
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-#if !defined (GHC_MASTER) && !defined (GHC_921)
+#if !defined (GHC_MASTER) && !defined (GHC_941) && !defined (GHC_921)
   , sPlatformConstants=platformConstants
 #endif
   , sToolSettings=toolSettings
@@ -118,7 +120,7 @@ fakeSettings = Settings
   }
 #endif
   where
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
     toolSettings = ToolSettings {
       toolSettings_opt_P_fingerprint=fingerprint0
       }
@@ -131,7 +133,7 @@ fakeSettings = Settings
 #endif
 
     platform =
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
       genericPlatform
 #else
       Platform{
@@ -176,7 +178,7 @@ fakeSettings = Settings
 #endif
 #endif
 
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
 fakeLlvmConfig = LlvmConfig [] []
 #else
@@ -184,13 +186,13 @@ fakeLlvmConfig :: (LlvmTargets, LlvmPasses)
 fakeLlvmConfig = ([], [])
 #endif
 
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 parse :: String -> DynFlags -> String -> ParseResult (Located HsModule)
 #else
 parse :: String -> DynFlags -> String -> ParseResult (Located (HsModule GhcPs))
 #endif
 parse filename flags str =
-#if defined (GHC_MASTER) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
   unP GHC.Parser.parseModule parseState
 #else
   unP Parser.parseModule parseState
@@ -199,7 +201,7 @@ parse filename flags str =
     location = mkRealSrcLoc (mkFastString filename) 1 1
     buffer = stringToStringBuffer str
     parseState =
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
       initParserState (initParserOpts flags) buffer location
 #else
       mkPState flags buffer location
@@ -208,7 +210,7 @@ parse filename flags str =
 parsePragmasIntoDynFlags :: DynFlags -> FilePath -> String -> IO (Maybe DynFlags)
 parsePragmasIntoDynFlags flags filepath str =
   catchErrors $ do
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
     let (_, opts) = getOptions (initParserOpts flags)
                       (stringToStringBuffer str) filepath
 #else
@@ -229,7 +231,7 @@ parsePragmasIntoDynFlags flags filepath str =
       putStrLn $ head
              [ showSDoc flags msg
              | msg <-
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
                       pprMsgEnvelopeBagWithLoc . getMessages
 #elif defined (GHC_921)
                       pprMsgEnvelopeBagWithLoc
@@ -245,14 +247,14 @@ idNot = mkVarUnqual (fsLit "not")
 
 isNegated :: HsExpr GhcPs -> Bool
 isNegated (HsApp _ (L _ (HsVar _ (L _ id))) _) = id == idNot
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
 isNegated (HsPar _ _ (L _ e) _) = isNegated e
 #else
 isNegated (HsPar _ (L _ e)) = isNegated e
 #endif
 isNegated _ = False
 
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
 analyzeExpr :: DynFlags -> LocatedA (HsExpr GhcPs) -> IO ()
 #else
 analyzeExpr :: DynFlags -> Located (HsExpr GhcPs) -> IO ()
@@ -261,7 +263,7 @@ analyzeExpr flags (L loc expr) = do
   case expr of
     HsApp _ (L _ (HsVar _ (L _ id))) (L _ e)
         | id == idNot, isNegated e ->
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
             putStrLn (showSDoc flags (ppr (locA loc))
 #else
             putStrLn (showSDoc flags (ppr loc)
@@ -270,7 +272,7 @@ analyzeExpr flags (L loc expr) = do
                       ++ "`" ++ showSDoc flags (ppr expr) ++ "'")
     _ -> return ()
 
-#if defined (GHC_MASTER) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
 analyzeModule :: DynFlags -> Located HsModule -> IO ()
 #elif defined (GHC_901)
 analyzeModule :: DynFlags -> Located HsModule -> ApiAnns -> IO ()
@@ -278,7 +280,7 @@ analyzeModule :: DynFlags -> Located HsModule -> ApiAnns -> IO ()
 analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> ApiAnns -> IO ()
 #endif
 analyzeModule flags (L _ modu)
-#if !(defined (GHC_MASTER) || defined (GHC_921))
+#if !(defined (GHC_MASTER) || defined(GHC_941) || defined (GHC_921))
                                 _ -- ApiAnns
 #endif
  = sequence_ [analyzeExpr flags e | e <- universeBi modu]
@@ -294,7 +296,7 @@ main = do
           (defaultDynFlags fakeSettings fakeLlvmConfig) file s
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
             PFailed s -> report flags $ GhcPsMessage <$> snd (getPsMessages s)
 #elif defined (GHC_921)
             PFailed s -> report flags $ fmap pprError (snd (getMessages s))
@@ -304,7 +306,7 @@ main = do
             PFailed _ loc err -> report flags $ unitBag $ mkPlainErrMsg flags loc err
 #endif
             POk s m -> do
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
               let (wrns, errs) = getPsMessages s
               report flags $ GhcPsMessage <$> wrns
               report flags $ GhcPsMessage <$> errs
@@ -319,13 +321,13 @@ main = do
 #endif
               when (null errs) $
                 analyzeModule flags m
-#if !(defined (GHC_MASTER) || defined (GHC_921))
+#if !(defined (GHC_MASTER) || defined(GHC_941) || defined (GHC_921))
                                       (harvestAnns s)
 #endif
     _ -> fail "Exactly one file argument required"
   where
 
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_941)
     -- Nowdays, to print hints along with errors you need 'printMessages'.
     -- See
     -- https://gitlab.haskell.org/ghc/ghc/-/merge_requests/6087#note_365215
@@ -346,7 +348,7 @@ main = do
 #  endif
         ]
 #endif
-#if !(defined(GHC_MASTER) || defined (GHC_921))
+#if !(defined(GHC_MASTER) || defined(GHC_941) || defined (GHC_921))
     harvestAnns pst =
 #  if defined (GHC_901)
         ApiAnns {

--- a/examples/mini-hlint/test/Main.hs
+++ b/examples/mini-hlint/test/Main.hs
@@ -1,5 +1,5 @@
--- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or
--- its affiliates. All rights reserved.  SPDX-License-Identifier:
+-- Copyright (c) 2021-2022, Digital Asset (Switzerland) GmbH and/or
+-- its affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 
 {-# OPTIONS_GHC -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans #-}
@@ -57,7 +57,7 @@ goldenTests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFla
     -- I judge it more work than it's worth to put in expect files
     -- configured for this case since the next stack release will fix
     -- it. So, for now just don't run this test.
-    (Just "../../stack-exact.yaml", Nothing) -> -- implicit resolver 'ghc-9.2.1'
+    (Just "../../stack-exact.yaml", Nothing) -> -- implicit resolver 'ghc-9.2.2'
       testGroup "mini-hlint tests" []
     (_, Just ghc) | ghc `elem` ["ghc-9.2.1", "ghc-9.2.2"] ->  -- explicit resolvers
       testGroup "mini-hlint tests" []
@@ -70,15 +70,16 @@ goldenTests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFla
          | hsFile <- filter (runTest ghcFlavor) hsFiles
          , let testName = hsFile
          , let expectFile =
-                 let f = case ghcFlavor of
-                       GhcMaster ->
+                 let f =
+                       if ghcFlavor `elem` [GhcMaster, Ghc941] then
                          case takeFileName hsFile of
                            "MiniHlintTest_fatal_error.hs" ->
                              takeDirectory hsFile </> "MiniHlintTest_fatal_error-ghc-master.hs"
                            "MiniHlintTest_non_fatal_error.hs" ->
                              takeDirectory hsFile </> "MiniHlintTest_non_fatal_error-ghc-master.hs"
                            _ -> hsFile
-                       _ -> hsFile
+                       else
+                         hsFile
                  in replaceExtension f $ (if isWindows then ".windows" else "") ++ ".expect"
          , let genStringAction = stack stackYaml stackResolver $ "--no-terminal exec -- mini-hlint " ++ hsFile
          ]

--- a/examples/test-utils/src/TestUtils.hs
+++ b/examples/test-utils/src/TestUtils.hs
@@ -1,5 +1,5 @@
--- Copyright (c) 2021, Digital Asset (Switzerland) GmbH and/or
--- its affiliates. All rights reserved.  SPDX-License-Identifier:
+-- Copyright (c) 2021-2022 Digital Asset (Switzerland) GmbH and/or its
+-- affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 {-# OPTIONS_GHC -Werror=unused-imports -Werror=unused-local-binds -Werror=unused-top-binds -Werror=orphans #-}
 {-# LANGUAGE LambdaCase #-}
@@ -36,6 +36,7 @@ data GhcVersion = DaGhc881
                 | Ghc902
                 | Ghc921
                 | Ghc922
+                | Ghc941
                 | GhcMaster
   deriving (Eq, Ord, Typeable)
 
@@ -44,6 +45,7 @@ instance Show GhcVersion where
 
 showGhcVersion :: GhcVersion -> String
 showGhcVersion = \case
+    Ghc941 -> "ghc-9.4.1"
     Ghc922 -> "ghc-9.2.2"
     Ghc921 -> "ghc-9.2.1"
     Ghc901 -> "ghc-9.0.1"
@@ -67,6 +69,7 @@ newtype GhcFlavor = GhcFlavor GhcVersion
 
 readFlavor :: String -> Maybe GhcFlavor
 readFlavor = (GhcFlavor <$>) . \case
+    "ghc-9.4.1" -> Just Ghc941
     "ghc-9.2.2" -> Just Ghc922
     "ghc-9.2.1" -> Just Ghc921
     "ghc-9.0.1" -> Just Ghc901

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -463,6 +463,7 @@ applyPatchDisableCompileTimeOptimizations ghcFlavor =
     let files =
           case ghcFlavor of
             GhcMaster -> [ "compiler/GHC/Driver/Session.hs", "compiler/GHC/Hs.hs" ]
+            Ghc941 ->    [ "compiler/GHC/Driver/Session.hs", "compiler/GHC/Hs.hs" ]
             Ghc922 ->    [ "compiler/GHC/Driver/Session.hs", "compiler/GHC/Hs.hs" ]
             Ghc921 ->    [ "compiler/GHC/Driver/Session.hs", "compiler/GHC/Hs.hs" ]
             Ghc901 ->    [ "compiler/GHC/Driver/Session.hs", "compiler/GHC/Hs.hs" ]
@@ -988,7 +989,8 @@ baseBounds ghcFlavor =
     Ghc921    -> "base >= 4.14 && < 4.16.1" -- [ghc-8.10.1, ghc-9.2.2)
     Ghc922    -> "base >= 4.14 && < 4.17" -- [ghc-8.10.1, ...)
 
-    GhcMaster -> "base >= 4.14 && < 4.17" -- [ghc-8.10.1, ...)
+    Ghc941   -> "base >= 4.14 && < 4.18" -- [ghc-8.10.1, )
+    GhcMaster -> "base >= 4.14 && < 4.18" -- [ghc-8.10.1, ...)
 
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1085,7 +1085,7 @@ generateGhcLibCabal ghcFlavor = do
           (Set.fromList parserModules))
 
     writeFile "ghc-lib.cabal" $ unlines $ map trimEnd $
-        [ "cabal-version: >=1.22"
+        [ "cabal-version: 2.0"
         , "build-type: Simple"
         , "name: ghc-lib"
         , "version: 0.1.0"
@@ -1120,7 +1120,7 @@ generateGhcLibCabal ghcFlavor = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (withCommas (ghcLibBuildDepends ghcFlavor))++
-        [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
+        [ "    build-tool-depends: alex:alex >= 3.1, happy:happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "    hs-source-dirs:" ] ++
@@ -1174,7 +1174,7 @@ generateGhcLibParserCabal :: GhcFlavor -> IO ()
 generateGhcLibParserCabal ghcFlavor = do
     (lib, _bin, parserModules) <- libBinParserModules ghcFlavor
     writeFile "ghc-lib-parser.cabal" $ unlines $ map trimEnd $
-        [ "cabal-version: >=1.22"
+        [ "cabal-version: 2.0"
         , "build-type: Simple"
         , "name: ghc-lib-parser"
         , "version: 0.1.0"
@@ -1214,7 +1214,7 @@ generateGhcLibParserCabal ghcFlavor = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (withCommas (ghcLibParserBuildDepends ghcFlavor)) ++
-        [ "    build-tools: alex >= 3.1, happy >= 1.19.4"
+        [ "    build-tool-depends: alex:alex >= 3.1, happy:happy >= 1.19.4"
         , "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++
         [ "    c-sources:" ] ++

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -80,6 +80,7 @@ data GhcFlavor = DaGhc881
                | Ghc902
                | Ghc921
                | Ghc922
+               | Ghc941
                | GhcMaster
     deriving (Show, Eq, Ord)
 
@@ -91,6 +92,7 @@ ghcFlavorOpt = option readFlavor
 
 readFlavor :: ReadM GhcFlavor
 readFlavor = eitherReader $ \case
+    "ghc-9.4.1" -> Right Ghc941
     "ghc-9.2.2" -> Right Ghc922
     "ghc-9.2.1" -> Right Ghc921
     "ghc-9.0.1" -> Right Ghc901
@@ -108,4 +110,4 @@ readFlavor = eitherReader $ \case
     "ghc-8.8.4" -> Right Ghc884
     "da-ghc-8.8.1" -> Right DaGhc881
     "ghc-master" -> Right GhcMaster
-    flavor -> Left $ "Failed to parse ghc flavor " <> show flavor <> " expected ghc-master, ghc-9.0.1, ghc-8.8.1, ghc-8.8.2, ghc-8.8.3, ghc-8.8.4, da-ghc-8.8.1, ghc-8.10.1, ghc-8.10.2, ghc-8.10.3, ghc-8.10.4, ghc-8.10.5, ghc-8.10.6, ghc-8.10.7, ghc-9.0.1, ghc-9.0.2, ghc-9.2.1 or ghc-9.2.2"
+    flavor -> Left $ "Failed to parse ghc flavor " <> show flavor <> " expected ghc-master, ghc-9.0.1, ghc-8.8.1, ghc-8.8.2, ghc-8.8.3, ghc-8.8.4, da-ghc-8.8.1, ghc-8.10.1, ghc-8.10.2, ghc-8.10.3, ghc-8.10.4, ghc-8.10.5, ghc-8.10.6, ghc-8.10.7, ghc-9.0.1, ghc-9.0.2, ghc-9.2.1, ghc-9.2.2 or ghc-9.4.1"


### PR DESCRIPTION
ghc-9.4.1-alpha has been announced. add experimental support for `ghc-flavor=ghc-9.4.1`. before landing let's:
- first land https://github.com/digital-asset/ghc-lib/pull/361
- then rebase this PR on master
- then test & land this.