### PR TITLE
no longer require fake llvm config

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -69,7 +69,7 @@ data GhcFlavor = Ghc941
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "a7053a6c04496fa26a62bb3824ccc9664909a6ec" -- 2022-05-01
+current = "35bdab1cb97f0be0ebea7cc93b977759f51d976c" -- 2022-05-19
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -61,16 +61,17 @@ strategy:
     # | linux   | ghc-9.4.1       | ghc-9.2.2  |
     # | macOS   | ghc-9.4.1       | ghc-9.2.2  |
     # +---------+-----------------+------------+
-    linux-ghc-9.4.1-9.2.2:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "ghc-9.2.2"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.4.1-9.2.2:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "ghc-9.2.2"
-      stack-yaml: "stack-exact.yaml"
+    # broken at least of 2022-05-19 (errors in ghc-lib-gen: ghc-lib/stage0/libraries/bytestring/build/Data/ByteString/Internal.o)
+    # linux-ghc-9.4.1-9.2.2:
+    #   image: "ubuntu-latest"
+    #   mode: "--ghc-flavor ghc-9.4.1"
+    #   resolver: "ghc-9.2.2"
+    #   stack-yaml: "stack-exact.yaml"
+    # mac-ghc-9.4.1-9.2.2:
+    #   image: "macOS-latest"
+    #   mode: "--ghc-flavor ghc-9.4.1"
+    #   resolver: "ghc-9.2.2"
+    #   stack-yaml: "stack-exact.yaml"
 
     # just can't get a build-plan at this time. issues with extra,
     # directory, process & time
@@ -167,6 +168,10 @@ strategy:
       resolver: "nightly-2020-01-08"
       stack-yaml: "stack.yaml"
 
+    # These builds are broken as of at least 2022-05-19. This commit
+    # to da-ghc seems related
+    # https://github.com/digital-asset/ghc/commit/e782ba91ad9007c5ac341676e3526f34e4e3e404
+    # ?
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
@@ -174,21 +179,21 @@ strategy:
     # | windows | da-ghc-8.8.1    | ghc-8.8.1  |
     # | macOS   | da-ghc-8.8.1    | ghc-8.8.1  |
     # +---------+-----------------+------------+
-    linux-da-ghc-8.8.1-8.8.1:
-      image: "ubuntu-latest"
-      mode: "--da"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-    windows-da-ghc-8.8.1-8.8.1:
-      image: "windows-latest"
-      mode: "--da"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-    mac-da-ghc-8.8.1-8.8.1:
-      image: "macOS-latest"
-      mode: "--da"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
+    # linux-da-ghc-8.8.1-8.8.1:
+    #   image: "ubuntu-latest"
+    #   mode: "--da"
+    #   resolver: "nightly-2020-01-08"
+    #   stack-yaml: "stack.yaml"
+    # windows-da-ghc-8.8.1-8.8.1:
+    #   image: "windows-latest"
+    #   mode: "--da"
+    #   resolver: "nightly-2020-01-08"
+    #   stack-yaml: "stack.yaml"
+    # mac-da-ghc-8.8.1-8.8.1:
+    #   image: "macOS-latest"
+    #   mode: "--da"
+    #   resolver: "nightly-2020-01-08"
+    #   stack-yaml: "stack.yaml"
 
 pool: {vmImage: '$(image)'}
 

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -106,7 +106,11 @@ mkDynFlags filename s = do
 #endif
   next_temp_suffix <- newIORef 0
   let baseFlags =
+#if defined (GHC_MASTER)
+        (defaultDynFlags fakeSettings) {
+#else
         (defaultDynFlags fakeSettings fakeLlvmConfig) {
+#endif
           ghcLink = NoLink
 #if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
         , backend = NoBackend
@@ -153,7 +157,9 @@ mkDynFlags filename s = do
       (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
       return dflags
 
-#if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER)
+-- Intentionally empty
+#elif defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
 fakeLlvmConfig = LlvmConfig [] []
 #else

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -164,7 +164,9 @@ fakeSettings = Settings
     platformConstants = PlatformConstants{ pc_DYNAMIC_BY_DEFAULT=False, pc_WORD_SIZE=8 }
 #endif
 
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER)
+-- Intentionally empty
+#elif defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
 fakeLlvmConfig = LlvmConfig [] []
 #else
@@ -279,7 +281,11 @@ main = do
       s <- readFile' file
       flags <-
         parsePragmasIntoDynFlags
+#if defined(GHC_MASTER)
+          (defaultDynFlags fakeSettings) file s
+#else
           (defaultDynFlags fakeSettings fakeLlvmConfig) file s
+#endif
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
 #if defined (GHC_MASTER) || defined (GHC_941)


### PR DESCRIPTION
- `LllvmConfig` is no longer stored in `DynFlags` (reference [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/ef3c8d9e077a1d4ede0724075489fb1f12afa3f9)). fix the examples accordingly
- the 9.4.1 (alpha) branch is looking broken right now so disable that flavor of build for now
- da-ghc builds also removed as they are broken presumbably by https://github.com/digital-asset/ghc/pull/119