### PR TITLE
tweak mini-compile cabal file

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -69,7 +69,7 @@ data GhcFlavor = Ghc941
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ffbe28e56aa382164525300fbc32d78eefd95e7d" -- 2022-05-23
+current = "d0e4355af8c936a3ba831ecf6afa62b06475069f" -- 2022-05-26
 
 -- Command line argument generators.
 

--- a/examples/mini-compile/mini-compile.cabal
+++ b/examples/mini-compile/mini-compile.cabal
@@ -15,8 +15,12 @@ executable mini-compile
                      , containers
                      , directory
                      , extra
-                     , ghc-lib-parser
                      , ghc-lib
+  -- ghc-lib re-exports ghc-lib-parser so this shouldn't be necessary
+  -- but >= ghc-9.0.2 seems broken in this respect.
+  if impl(ghc >= 9.0.2) && impl  (ghc > 9.3)
+    build-depends:     ghc-lib-parser
+
   default-language:    Haskell2010
   hs-source-dirs:      src
   if flag(daml-unit-ids)

--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -23,7 +23,6 @@ module Main (main) where
 -- ghc-lib re-exports the modules of ghc-lib-parser. Before 9.2.1 we
 -- couldn't refer to them as being in the ghc-lib package (and instead
 -- had to refer to them as being in the ghc-lib-parser package).
-
 #if __GLASGOW_HASKELL__ > 902
 # define GHC_LIB_PARSER_PKG "ghc-lib"
 #else


### PR DESCRIPTION
i glossed over this in https://github.com/digital-asset/ghc-lib/pull/372 but 9.0.2 seems to be broken in the following way: `ghc-lib` re-exports `ghc-lib-parser` so it shouldn't be necessary to `build-depend` on `ghc-lib-parser` when you `build-depend` on on `ghc-lib`.  i worked around 9.0.2 appearing to violate this rule by adding an unconditional `build-depend` of mini-compile on `ghc-lib-parser`. i'm circling back in this PR and making it conditional on `>=9.0.2 && <9.3` (i'll also mention that i manually ran this patch with ghc-9.0.1 and it was ok  there too as i expected)