### PR TITLE
[ghc-lib-gen]: bushfix ghc-9.4.1 does not compile with XXX

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,25 +55,22 @@ strategy:
       resolver: "ghc-9.2.2"
       stack-yaml: "stack-exact.yaml"
 
-    # still broken as of 2022-06-24: see
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/21633 and
-    # https://gitlab.haskell.org/ghc/ghc/-/issues/21634
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-9.4.1       | ghc-9.2.2  |
     # | macOS   | ghc-9.4.1       | ghc-9.2.2  |
     # +---------+-----------------+------------+
-    # linux-ghc-9.4.1-9.2.2:
-    #   image: "ubuntu-latest"
-    #   mode: "--ghc-flavor ghc-9.4.1"
-    #   resolver: "ghc-9.2.2"
-    #   stack-yaml: "stack-exact.yaml"
-    # mac-ghc-9.4.1-9.2.2:
-    #   image: "macOS-latest"
-    #   mode: "--ghc-flavor ghc-9.4.1"
-    #   resolver: "ghc-9.2.2"
-    #   stack-yaml: "stack-exact.yaml"
+    linux-ghc-9.4.1-9.2.2:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-9.4.1"
+      resolver: "ghc-9.2.2"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-9.4.1-9.2.2:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-9.4.1"
+      resolver: "ghc-9.2.2"
+      stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavour | GHC        |


### PR DESCRIPTION
- put in a temporary fix for the `ghc-9.4.1` flavor build failures
- while we are it get out in front of a required update to `Ghclibgen.commonBuildDepends`
- re-enable tests for 9.4.1 builds in azure
