### PR TITLE
Fix DA CI

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -213,14 +213,14 @@ parseOptions = Options
        Opts.flag' DaFlavor ( Opts.long "da" <> Opts.help "Enables DA custom build." )
        <*> Opts.strOption
            ( Opts.long "merge-base-sha"
-          <> Opts.help "DA flavour only. Base commit to use from the GHC repo."
+          <> Opts.help "DA flavor only. Base commit to use from the GHC repo."
           <> Opts.showDefault
           <> Opts.value "ghc-8.8.1-release"
            )
        <*> (Opts.some
              (Opts.strOption
               ( Opts.long "patch"
-             <> Opts.help "DA flavour only. Commits to merge in from the DA GHC fork, referenced as 'upstream'. Can be specified multiple times. If no patch is specified, default will be equivalent to `--patch upstream/da-master-8.8.1`. Specifying any patch will overwrite the default (i.e. replace, not add)."
+             <> Opts.help "DA flavor only. Commits to merge in from the DA GHC fork, referenced as 'upstream'. Can be specified multiple times. If no patch is specified, default will be equivalent to `--patch upstream/da-master-8.8.1`. Specifying any patch will overwrite the default (i.e. replace, not add)."
               ))
             Opts.<|>
             pure ["upstream/da-master-8.8.1"])

--- a/CI.hs
+++ b/CI.hs
@@ -215,10 +215,10 @@ parseOptions = Options
        <*> (Opts.some
              (Opts.strOption
               ( Opts.long "patch"
-             <> Opts.help "DA flavour only. Commits to merge in from the DA GHC fork, referenced as 'upstream'. Can be specified multiple times. If no patch is specified, default will be equivalent to `--patch upstream/da-master-8.8.1 --patch upstream/da-unit-ids-8.8.1`. Specifying any patch will overwrite the default (i.e. replace, not add)."
+             <> Opts.help "DA flavour only. Commits to merge in from the DA GHC fork, referenced as 'upstream'. Can be specified multiple times. If no patch is specified, default will be equivalent to `--patch upstream/da-master-8.8.1`. Specifying any patch will overwrite the default (i.e. replace, not add)."
               ))
             Opts.<|>
-            pure ["upstream/da-master-8.8.1", "upstream/da-unit-ids-8.8.1"])
+            pure ["upstream/da-master-8.8.1"])
        <*> Opts.strOption
            ( Opts.long "gen-flavor"
           <> Opts.help "DA flavor only. Flavor to pass on to ghc-lib-gen."

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ strategy:
     # supported).
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-master      | ghc-9.2.2  |
     # | macOS   | ghc-master      | ghc-9.2.2  |
@@ -56,7 +56,7 @@ strategy:
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-9.2.3       | ghc-9.2.2  |
     # | macOS   | ghc-9.2.3       | ghc-9.2.2  |
@@ -73,7 +73,7 @@ strategy:
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-9.4.1       | ghc-9.2.2  |
     # | macOS   | ghc-9.4.1       | ghc-9.2.2  |
@@ -90,7 +90,7 @@ strategy:
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-master      | ghc-9.0.2  |
     # | macOS   | ghc-master      | ghc-9.0.2  |
@@ -107,7 +107,7 @@ strategy:
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
     # | linux   | ghc-9.0.2       | ghc-8.10.7 |
     # | macOS   | ghc-9.0.2       | ghc-8.8.1  |
@@ -124,10 +124,10 @@ strategy:
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-8.10.7       | ghc-8.8.1 |
-    # | macOS   | ghc-8.10.7       | ghc-8.8.1 |
+    # | linux   | ghc-8.10.7      | ghc-8.8.1  |
+    # | macOS   | ghc-8.10.7      | ghc-8.8.1  |
     # +---------+-----------------+------------+
     linux-ghc-8.10.7-8.8.1:
       image: "ubuntu-latest"
@@ -141,7 +141,7 @@ strategy:
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavour | GHC        |
+    # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
     # | linux   | da-ghc-8.8.1    | ghc-8.8.1  |
     # | windows | da-ghc-8.8.1    | ghc-8.8.1  |


### PR DESCRIPTION
As @shayne-fletcher noticed (https://github.com/digital-asset/ghc-lib/pull/377#issuecomment-1145744271), the change from https://github.com/digital-asset/ghc/pull/123 & https://github.com/digital-asset/ghc-lib/pull/377 broke CI for the DA build. It didn't break on https://github.com/digital-asset/ghc-lib/pull/377 because https://github.com/digital-asset/ghc/pull/123 was merged after it. The fix is to drop the now-useless patch https://github.com/digital-asset/ghc/tree/da-unit-ids-8.8.1 and instead call `ghc-lib-gen` with the new `--cpp=-DDAML_PRIM` option for the DA flavor.

I also took the opportunity to extract the `Da` record variant of `GhcFlavor` into its own type, as well as replace all uses of "flavour" with the more frequent (in the repo) "flavor".