### PR TITLE
update stack-exact.yaml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,10 @@ strategy:
     # (the general rule is only the last two compiler versions are
     # supported).
 
+    # note(sf, 2022-0604): We should be able to bump this to ghc-9.2.3
+    # soon (see
+    # https://github.com/commercialhaskell/stackage-content/issues/103).
+
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
@@ -47,11 +51,28 @@ strategy:
     linux-ghc-master-9.2.2:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2022-05-27"
-      stack-yaml: "stack.yaml"
+      resolver: "ghc-9.2.2"
+      stack-yaml: "stack-exact.yaml"
     mac-ghc-master-9.2.2:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.2.2"
+      stack-yaml: "stack-exact.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavor  | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-9.4.1       | ghc-9.2.2  |
+    # | macOS   | ghc-9.4.1       | ghc-9.2.2  |
+    # +---------+-----------------+------------+
+    linux-ghc-9.4.1-9.2.2:
+      image: "ubuntu-latest"
+      mode: "--ghc-flavor ghc-9.4.1"
+      resolver: "nightly-2022-05-27"
+      stack-yaml: "stack.yaml"
+    mac-ghc-9.4.1-9.2.2:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-9.4.1"
       resolver: "nightly-2022-05-27"
       stack-yaml: "stack.yaml"
 
@@ -71,23 +92,6 @@ strategy:
       mode: "--ghc-flavor ghc-9.2.3"
       resolver: "nightly-2022-05-27"
       stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.4.1       | ghc-9.2.2  |
-    # | macOS   | ghc-9.4.1       | ghc-9.2.2  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.4.1-9.2.2:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "ghc-9.2.2"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.4.1-9.2.2:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "ghc-9.2.2"
-      stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -7,14 +7,7 @@
 # You can add --resolver xxx to the above command to have the effect
 # of overriding the choice of compiler if desired.
 
-# Stack 8.10 builds generate a lot of warnings of this kind.
-#   Warning: Failed to decode module interface:
-#            some/path/to/Main.hi
-#            Decoding failure: Invalid magic: e49ceb0f
-# This is a known upstream issue (see
-# https://github.com/commercialhaskell/stack/issues/5134).
-
-resolver: ghc-9.2.2
+resolver: ghc-9.2.3
 
 ghc-options:
   # Try to be quick.
@@ -22,27 +15,24 @@ ghc-options:
 
 extra-deps:
 # Dependencies of ghc-lib-parser & ghc-lib:
-- alex-3.2.6
+- alex-3.2.7.1
 # Most recent happy is 1.21.0 but we can't change yet. See:
-# - the `extra-deps` section of `stack-901.yaml`
-# - 'ghc/m4/fptools_happy.m4' which is what bounds ghc above to 1.20.0
+# 'ghc/m4/fptools_happy.m4' which is what bounds ghc above to 1.20.0
 - happy-1.20.0
 # Dependencies for ghc-lib examples:
-- hashable-1.4.0.0
+- hashable-1.4.0.2
 - syb-0.7.2.1
 - uniplate-1.6.13
-- unordered-containers-0.2.15.0
+- unordered-containers-0.2.19.1
 # Additional dependencies for CI.hs & ghc-lib-gen:
-- ansi-terminal-0.11
+- ansi-terminal-0.11.3
 - ansi-wl-pprint-0.6.9
-- clock-0.8.2
+- clock-0.8.3
 - colour-2.3.6
 - extra-1.7.10
 - mintty-0.1.3 # windows specific (but it does no harm).
-- Win32-2.13.1.0 # new mintty dependency
-- optparse-applicative-0.16.1.0
-- process-1.6.14.0
-- semigroups-0.19.2
+- Win32-2.13.2.0 # new mintty dependency
+- optparse-applicative-0.17.0.0
 - transformers-compat-0.7.1
 # ghc-lib-gen has recently started depending on yaml
 - OneTuple-0.3.1
@@ -53,15 +43,15 @@ extra-deps:
 - base-orphans-0.8.6
 - contravariant-1.5.5
 - integer-logarithms-1.0.3.1
-- random-1.2.1
+- random-1.2.1.1
 - split-0.2.3.4
 - vector-algorithms-0.8.0.4
-- bifunctors-5.5.11
+- bifunctors-5.5.12
 - splitmix-0.1.0.4
 - distributive-0.6.2.1
 - comonad-5.0.8
 - aeson-2.0.3.0
-- attoparsec-0.14.2
+- attoparsec-0.14.4
 - conduit-1.3.4.2
 - data-fix-0.3.2
 - dlist-1.0
@@ -69,11 +59,11 @@ extra-deps:
 - indexed-traversable-instances-0.1.1
 - libyaml-0.1.2
 - mono-traversable-1.0.15.3
-- primitive-0.7.3.0
-- resourcet-1.2.4.3
+- primitive-0.7.4.0
+- resourcet-1.2.5
 - scientific-0.3.7.0
 - semialign-1.2.0.1
-- semigroupoids-5.3.6
+- semigroupoids-5.3.7
 - strict-0.4.0.1
 - tagged-0.8.6.1
 - text-short-0.1.5
@@ -83,22 +73,19 @@ extra-deps:
 - unliftio-core-0.2.0.1
 - uuid-types-1.0.5
 - vector-0.12.3.1
-- yaml-0.11.7.0
+- yaml-0.11.8.0
 - witherable-0.4.2
 - QuickCheck-2.14.2
 # Dependencies (not already covered) for golden tests
-- tasty-1.4.2
-- tasty-golden-2.3.4
+- tasty-1.4.2.3
+- tasty-golden-2.3.5
+- typed-process-0.2.10.1
 - utf8-string-1.0.2
 - async-2.2.4
 - temporary-1.3
 - unbounded-delays-0.1.1.1
 - unix-compat-0.5.3
 - wcwidth-0.0.2
-
-flags:
-  transformers-compat:
-    five-three: true
 
 # Packages MUST go at the end, since we append to it during the CI.hs
 # script.


### PR DESCRIPTION
maintenance PR: update package versions in `stack-exact.yaml`.

when a PR for https://github.com/commercialhaskell/stackage-content/issues/103 lands, we'll bump to 9.2.3