### PR TITLE
enable ghc-9.2.3 builds

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -79,7 +79,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ffbe28e56aa382164525300fbc32d78eefd95e7d" -- 2022-05-23
+current = "04209f2a6a49f6cdc116b5cb73ccd1749c90f88b" -- 2022-06-07
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,25 +38,21 @@ strategy:
     # (the general rule is only the last two compiler versions are
     # supported).
 
-    # note(sf, 2022-0604): We should be able to bump this to ghc-9.2.3
-    # soon (see
-    # https://github.com/commercialhaskell/stackage-content/issues/103).
-
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.2.2  |
-    # | macOS   | ghc-master      | ghc-9.2.2  |
+    # | linux   | ghc-master      | ghc-9.2.3  |
+    # | macOS   | ghc-master      | ghc-9.2.3  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.2.2:
+    linux-ghc-master-9.2.3:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.2.2"
+      resolver: "ghc-9.2.3"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.2.2:
+    mac-ghc-master-9.2.3:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.2.2"
+      resolver: "ghc-9.2.3"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+


### PR DESCRIPTION
as discussed in https://github.com/digital-asset/ghc-lib/pull/381, `resolver: ghc-9.2.3` is now available so this PR enables `ghc-flavor master` builds that use it.