### PR TITLE
constrain xcrun fix to ghc-9.2.2

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -436,12 +436,15 @@ buildDists
       -- 7762 means this shouldn't be an issue anymore going forward.
       ghcOptionsWithHaddock = ghcOptionsOpt
 
-      -- Mitigate macOS w/[ghc-9.0 <= 9.2.2] build failures for lack of
-      -- this c-include path (including e.g. ghc-lib-parser on
-      -- ghc-9.2.2). See
+      -- Mitigate against macOS/ghc-9.2.2 failures for lack of this
+      -- c-include path. See
       -- https://gitlab.haskell.org/ghc/ghc/-/issues/20592#note_391266.
+      -- There are reports that this exhibits with 9.0.2 and 9.2.1 as
+      -- well but I haven't observed that.
       prelude :: (String, String) -> String
+#if __GLASGOW_HASKELL__ == 902 && __GLASGOW_HASKELL_PATCHLEVEL1__ == 2
       prelude ("darwin", _) = "C_INCLUDE_PATH=`xcrun --show-sdk-path`/usr/include/ffi"
+#endif
       prelude _ = ""
 
       stack :: String -> IO ()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -117,7 +117,7 @@ strategy:
       mode: "--ghc-flavor ghc-9.0.2"
       resolver: "lts-18.16"
       stack-yaml: "stack.yaml"
-    mac-ghc-9.0.2-8.10.7:
+    mac-ghc-9.0.2-8.8.1:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.0.2"
       resolver: "nightly-2020-01-08"

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -991,9 +991,9 @@ baseBounds ghcFlavor =
     Ghc922    -> "base >= 4.14 && < 4.16.2" -- [ghc-8.10.1, ghc-9.2.3)
     Ghc923    -> "base >= 4.14 && < 4.17" -- [ghc-8.10.1, ghc-9.4.1)
 
-    Ghc941   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.2, ghc-9.6.1)
+    Ghc941   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
 
-    GhcMaster -> "base >= 4.15 && < 4.18" -- [ghc-9.0.2, ghc-9.6.1)
+    GhcMaster -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
 
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]


### PR DESCRIPTION
this is confirmed fixed in 9.2.3 and i haven't been able to make it manifest in any of 9.0.1, 9.0.2, 9.2.1 so let's just constrain this to 9.2.2 (see https://github.com/digital-asset/ghc-lib/issues/352 and https://gitlab.haskell.org/ghc/ghc/-/issues/20592).