### PR TITLE
add skip-init flag

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -355,8 +355,9 @@ buildDists
     cmd "git checkout stack.yaml"
 
     -- Make and extract an sdist of ghc-lib.
-    cmd "cd ghc && git checkout ."
-    stack $ "exec -- ghc-lib-gen ghc --ghc-lib " ++ ghcFlavorOpt ghcFlavor ++ " " ++ cppOpts ghcFlavor
+    -- cmd "cd ghc && git checkout ."
+    cmd "cd ghc"
+    stack $ "exec -- ghc-lib-gen ghc --ghc-lib " ++ ghcFlavorOpt ghcFlavor ++ " " ++ cppOpts ghcFlavor ++ " " ++ "--skip-init"
     patchVersion version "ghc/ghc-lib.cabal"
     patchConstraint version "ghc/ghc-lib.cabal"
     mkTarball pkg_ghclib

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -23,8 +23,9 @@ data GhclibgenTarget = GhclibParser | Ghclib
 -- | The type of ghc-lib-gen options.
 data GhclibgenOpts = GhclibgenOpts {
     ghclibgenOpts_root :: !FilePath -- ^ Path to a GHC git repository.
-  , ghclibgenOpts_target :: !GhclibgenTarget -- ^ What target?
+  , ghclibgenOpts_target :: !GhclibgenTarget
   , ghclibgenOpts_ghcFlavor :: !GhcFlavor
+  , ghclibgenOpts_skipInit :: !Bool
   , ghclibgenOpts_customCppFlags :: ![String]
  }
 
@@ -61,6 +62,10 @@ ghclibgenOpts = GhclibgenOpts
   <$> argument str (metavar "GHC_ROOT")
   <*> ghclibgenTarget
   <*> ghcFlavorOpt
+  <*> switch
+        ( long "skip-init"
+        <> help "If enabled, skip initialization steps"
+        )
   <*> cppCustomFlagsOpt
 
 -- | We might want to factor this out so we can share it with CI.hs


### PR DESCRIPTION
this PR delivers a 16% (rel) wall-time reduction in overall execution of CI.hs by making sure to perform initialization and parser-depends steps in CI only once
- add a flag `skip-init` to `ghc-lib-gen`
- in CI.hs `stack exec -- ghc-lib-gen ghc-lib --skip-init`

```
before
      375.78 real      1097.31 user       380.80 sys
after
      323.39 real      1073.91 user       353.09 sys
```
