### PR TITLE
rm duplicate line

### DIFF
--- a/examples/test-utils/test-utils.cabal
+++ b/examples/test-utils/test-utils.cabal
@@ -10,17 +10,15 @@ maintainer:          Shayne Fletcher (shayne@shaynefletcher.org) & Digital Asset
 copyright:           Digital Asset 2021-2022
 category:            Development
 build-type:          Simple
-category:            Development
 description:         Code common to usage examples
 
 library
   hs-source-dirs:    src
   default-language:  Haskell2010
-  build-depends:
-      base >=4.11 && <5
-    , extra
-    , tasty
-    , utf8-string
+  build-depends:     base >=4.11 && <5
+                   , extra
+                   , tasty
+                   , utf8-string
   exposed-modules:   TestUtils
   other-modules:     Paths_test_utils
   autogen-modules:   Paths_test_utils


### PR DESCRIPTION
a duplicate line crept into a cabal file. this fixes it and takes the opportunity to reformat a section of it in accordance with the majority of the others.