### PR TITLE
make sdists of examples

### DIFF
--- a/examples/mini-compile/mini-compile.cabal
+++ b/examples/mini-compile/mini-compile.cabal
@@ -12,6 +12,8 @@ build-type:          Simple
 category:            Development
 description:         "ghc-lib" usage example
 
+extra-source-files:  test/*.hs
+
 executable mini-compile
   main-is:             Main.hs
   default-language:    Haskell2010

--- a/examples/mini-hlint/mini-hlint.cabal
+++ b/examples/mini-hlint/mini-hlint.cabal
@@ -12,6 +12,9 @@ build-type:          Simple
 category:            Development
 description:         "ghc-lib-parser" usage example
 
+extra-source-files:  test/*.hs
+                     test/*.expect
+
 executable mini-hlint
   main-is:             Main.hs
   default-language:    Haskell2010
@@ -25,12 +28,9 @@ executable mini-hlint
 test-suite mini-hlint-test
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
-  main-is:
-                       Main.hs
-  hs-source-dirs:
-                       test
-  build-depends:
-                       base >=4.11 && <5
+  main-is:             Main.hs
+  hs-source-dirs:      test
+  build-depends:       base >=4.11 && <5
                      , directory
                      , extra
                      , filepath


### PR DESCRIPTION
add a little code to `CI.hs` that produces sdist of `test-utils`, `mini-hlint`, `mini-compile`. although we don't publish these on hackage doing this enables me to treat them uniformly with `ghc-lib-parser`, `ghc-lib` and `hlint` in my local end-to-end tests (takes a step closer to getting them in a state suitable for the hlint repo)