### PR TITLE
Fix ghc-lib build failure with 8.10.7 and -haddock

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ strategy:
     #      | ghc-8.8.*    |  >= 8.4.4   |
     #      | ghc-8.10.*   |  >= 8.6.5   |
     #      | ghc-9.0.*    |  >= 8.8.1   |
-    #      | ghc-9.2.1    |  >= 8.10.1  |
+    #      | ghc-9.2.*    |  >= 8.10.1  |
     #      | >= ghc-9.4.1 |  >= 9.0.1   |
     #      +--------------+-------------+
     # (the general rule is only the last two compiler versions are

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -629,9 +629,16 @@ applyPatchHaddockHs ghcFlavor = do
         "-- -"
     =<< readFile' ffiClosuresHs
     )
+  -- See https://github.com/digital-asset/ghc-lib/issues/391
+  when (ghcFlavor == Ghc923) (
+    writeFile codeGenHs . replace "{- | debugIsOn -}"  ""
+    =<< readFile' codeGenHs
+    )
+
   where
     haddockHs = "compiler/GHC/Parser/PostProcess/Haddock.hs"
     ffiClosuresHs = "libraries/ghc-heap/GHC/Exts/Heap/FFIClosures.hs"
+    codeGenHs = "compiler/GHC/CmmToAsm/AArch64/CodeGen.hs"
 
 -- Support for unboxed tuples got landed 03/20/2021
 -- (https://gitlab.haskell.org/ghc/ghc/-/commit/1f94e0f7601f8e22fdd81a47f130650265a44196#4ec156a7b95e9c7a690c99bc79e6e0edf60a51dc)


### PR DESCRIPTION
`ghc-9.2.3` flavored `ghc-lib` builds fail with ghc-8.10.* when `-haddock` is enabled due to a particular comment. 
- upstream ticket https://gitlab.haskell.org/ghc/ghc/-/issues/20920
- relates to issue https://github.com/digital-asset/ghc-lib/issues/344
- fixes https://github.com/digital-asset/ghc-lib/issues/391

packages produced via:
```
stack runhaskell \
  --package extra --package optparse-applicative CI.hs -- \
  --ghc-flavor ghc-9.2.3 
```

tested with this `cabal.project`:
```
packages:    */*.cabal
with-compiler: /Users/shayne/ghc-8.10.7/bin/ghc
package ghc-lib-parser
  ghc-options: -j -haddock   
package ghc-lib
  ghc-options: -haddock
```
before the fix, `cabal new-build all` produces:
```
compiler/GHC/CmmToAsm/AArch64/CodeGen.hs:176:15: error:
    parse error on input ‘{- | debugIsOn -}’
    |
176 | ann doc instr {- | debugIsOn -} = ANN doc instr
    |               ^^^^^^^^^^^^^^^^^
```
after the fix `cabal new-build all` runs to completion.