### PR TITLE
reintroduce GhcPs to HsModule per ttg: move HsModule to LHS

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -79,7 +79,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ac83899dcb5931913699d191f2c46780483ed07e" -- 2022-06-15
+current = "620ee7edc931dc5273dd04880059cc9ec8d41528" -- 2022-07-05
 
 -- Command line argument generators.
 

--- a/examples/mini-hlint/src/Main.hs
+++ b/examples/mini-hlint/src/Main.hs
@@ -174,7 +174,7 @@ fakeLlvmConfig :: (LlvmTargets, LlvmPasses)
 fakeLlvmConfig = ([], [])
 #endif
 
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 parse :: String -> DynFlags -> String -> ParseResult (Located HsModule)
 #else
 parse :: String -> DynFlags -> String -> ParseResult (Located (HsModule GhcPs))
@@ -260,7 +260,9 @@ analyzeExpr flags (L loc expr) = do
                       ++ "`" ++ showSDoc flags (ppr expr) ++ "'")
     _ -> return ()
 
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER)
+analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> IO ()
+#elif defined (GHC_941) || defined (GHC_921)
 analyzeModule :: DynFlags -> Located HsModule -> IO ()
 #elif defined (GHC_901)
 analyzeModule :: DynFlags -> Located HsModule -> ApiAnns -> IO ()


### PR DESCRIPTION
change kind of`HsModule`
- upstream commit https://gitlab.haskell.org/ghc/ghc/-/commit/3a8970ac0c69335a1d229f9c9a71e6e333e99bfb#fab0be96f273c672b4cf5951580807a053ce05fe)
- update `mini-hlint`