### PR TITLE
small bugfix in bounds patching

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -497,6 +497,9 @@ buildDists
       patchConstraints :: String -> FilePath -> IO ()
       patchConstraints version file =
         writeFile file .
+          -- affects ghc-lib.cabal
+          replace "ghc-lib-parser\n" ("ghc-lib-parser == " ++ version ++ "\n") .
+          -- affects test-utils, mini-hlint, mini-compile
           replace ", test-utils\n" (", test-utils == " ++ version ++ "\n") .
           replace ", ghc-lib\n" (", ghc-lib == " ++ version ++ "\n") .
           replace ", ghc-lib-parser\n" (", ghc-lib-parser == " ++ version ++ "\n")


### PR DESCRIPTION
a recent refactoring accidentally resulted in stopping `CI.hs` from expressing a `ghc-lib-parser` bound in `ghc-lib.cabal`. this change fixes that.