### PR TITLE
add new flag to skip building things

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -14,6 +14,7 @@ import System.Info.Extra
 import System.Process.Extra
 import System.Time.Extra
 import System.Info (os, arch)
+import System.Exit
 import Data.Maybe
 import Data.List.Extra
 import Data.Time.Clock
@@ -28,13 +29,14 @@ main = do
             <> Opts.progDesc "Build ghc-lib and ghc-lib-parser tarballs."
             <> Opts.header "CI - CI script for ghc-lib"
           )
-    Options { ghcFlavor, noGhcCheckout, stackOptions, versionSuffix } <- Opts.execParser opts
-    version <- buildDists ghcFlavor noGhcCheckout stackOptions versionSuffix
+    Options { ghcFlavor, noGhcCheckout, noBuilds, stackOptions, versionSuffix } <- Opts.execParser opts
+    version <- buildDists ghcFlavor noGhcCheckout noBuilds stackOptions versionSuffix
     putStrLn version
 
 data Options = Options
     { ghcFlavor :: GhcFlavor
     , noGhcCheckout :: Bool
+    , noBuilds :: Bool
     , stackOptions :: StackOptions
     , versionSuffix :: Maybe String
     } deriving (Show)
@@ -179,6 +181,10 @@ parseOptions = Options
           ( Opts.long "no-checkout"
           <> Opts.help "If enabled, don't perform a GHC checkout"
           )
+    <*> Opts.switch
+          ( Opts.long "no-builds"
+          <> Opts.help "If enabled, don't build & test packages & examples"
+          )
     <*> parseStackOptions
     <*> Opts.optional
           ( Opts.strOption
@@ -265,10 +271,11 @@ parseStackOptions = StackOptions
        <> Opts.help "If specified, pass '--ghc-options=\"xxx\"' to stack"
         ))
 
-buildDists :: GhcFlavor -> Bool -> StackOptions -> Maybe String -> IO String
+buildDists :: GhcFlavor -> Bool -> Bool -> StackOptions -> Maybe String -> IO String
 buildDists
   ghcFlavor
   noGhcCheckout
+  noBuilds
   StackOptions {stackYaml, resolver, verbosity, cabalVerbose, ghcOptions}
   versionSuffix
   =
@@ -362,6 +369,8 @@ buildDists
     renameDirectory pkg_ghclib "ghc-lib"
     removeFile "ghc/ghc-lib.cabal"
     cmd "git checkout stack.yaml"
+
+    when noBuilds exitSuccess
 
     -- Append the libraries and examples to the prevailing stack
     -- configuration file.

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1364,7 +1364,4 @@ genPlaceholderModules = loop
       if isDir then do
         contents <- listDirectory fp
         mapM_ (loop . (fp </>)) contents
-      else if takeExtension fp `elem` [".x", ".y", ".hsc"] then
-        genPlaceholderModule fp
-      else
-        pure ()
+      else when (takeExtension fp `elem` [".x", ".y", ".hsc"]) $ genPlaceholderModule fp


### PR DESCRIPTION
add `CI.hs` option `--no-builds`. when this switch is provided, `CI.hs` will terminate immediately after it has written ghc-lib package archives `.tar.gz`. that is, the packages themselves and the examples are neither built nor tested. this enables a quick end-to-end testing capability for hlint.