### PR TITLE
ghc-9.4.1: vendored filepath workaround

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -81,7 +81,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "460505345e500eb902da9737c75c077d5fc5ef66" -- 2022-07-10
+current = "dcf8b30a1a5f802b1d8a22ea74499e2896a6ff16" -- 2022-07-14
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -403,7 +403,7 @@ calcParserModules ghcFlavor = do
 
 applyPatchTemplateHaskellCabal :: GhcFlavor -> IO ()
 applyPatchTemplateHaskellCabal ghcFlavor = do
-  when (ghcFlavor == GhcMaster) $ do
+  when (ghcFlavor `elem` [GhcMaster, Ghc941]) $ do
     -- In
     -- https://gitlab.haskell.org/ghc/ghc/-/commit/b151b65ec469405dcf25f9358e7e99bcc8c2b3ac
     -- (2022/7/05) a temporary change is made to provide for vendoring


### PR DESCRIPTION
the template haskell vendor filepath hack got ported to ghc-9.4. extend `applyPathTemplateHaskellCabal` for flavor `ghc-9.4.1`   accordingly.