### PR TITLE
update ghc-9.4.1 to release branch

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -82,7 +82,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "9ea29d47bbeac7abf54c9c05d105bb6f21d4c083" -- 2022-07-27
+current = "78d04cfadfd728bb088b08b1e88905b43cc0360c" -- 2022-08-07
 
 -- Command line argument generators.
 
@@ -315,7 +315,7 @@ buildDists
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
     case ghcFlavor of
-        Ghc941 -> cmd "cd ghc && git checkout ghc-9.4"
+        Ghc941 -> cmd "cd ghc && git checkout ghc-9.4.1-release"
         Ghc924 -> cmd "cd ghc && git checkout ghc-9.2.4-release"
         Ghc923 -> cmd "cd ghc && git checkout ghc-9.2.3-release"
         Ghc922 -> cmd "cd ghc && git checkout ghc-9.2.2-release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,8 @@ strategy:
     #      | ghc-8.10.*   |  >= 8.6.5   |
     #      | ghc-9.0.*    |  >= 8.8.1   |
     #      | ghc-9.2.*    |  >= 8.10.1  |
-    #      | >= ghc-9.4.1 |  >= 9.0.1   |
+    #      | ghc-9.4.1    |  >= 9.0.1   |
+    #      | > ghc-9.4.1  |  >= 9.2.1   |
     #      +--------------+-------------+
     # (the general rule is only the last two compiler versions are
     # supported).
@@ -41,47 +42,47 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.2.3  |
-    # | macOS   | ghc-master      | ghc-9.2.3  |
-    # | windows | ghc-master      | ghc-9.2.3  |
+    # | linux   | ghc-master      | ghc-9.2.4  |
+    # | macOS   | ghc-master      | ghc-9.2.4  |
+    # | windows | ghc-master      | ghc-9.2.4  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.2.3:
+    linux-ghc-master-9.2.4:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.2.3"
+      resolver: "ghc-9.2.4"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.2.3:
+    mac-ghc-master-9.2.4:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.2.3"
+      resolver: "ghc-9.2.4"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.2.3:
+    windows-ghc-master-9.2.4:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2022-06-20"
+      resolver: "nightly-2022-08-04"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-9.4.1       | ghc-9.2.3  |
-    # | macOS   | ghc-9.4.1       | ghc-9.2.3  |
-    # | windows | ghc-9.4.1       | ghc-9.2.3  |
+    # | linux   | ghc-9.4.1       | ghc-9.2.4  |
+    # | macOS   | ghc-9.4.1       | ghc-9.2.4  |
+    # | windows | ghc-9.4.1       | ghc-9.2.4  |
     # +---------+-----------------+------------+
-    linux-ghc-9.4.1-9.2.3:
+    linux-ghc-9.4.1-9.2.4:
       image: "ubuntu-latest"
       mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "nightly-2022-07-28"
+      resolver: "nightly-2022-08-04"
       stack-yaml: "stack.yaml"
-    mac-ghc-9.4.1-9.2.3:
+    mac-ghc-9.4.1-9.2.4:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "nightly-2022-07-28"
+      resolver: "nightly-2022-08-04"
       stack-yaml: "stack.yaml"
-    windows-ghc-9.4.1-9.2.3:
+    windows-ghc-9.4.1-9.2.4:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.4.1"
-      resolver: "nightly-2022-07-28"
+      resolver: "nightly-2022-08-04"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -412,19 +412,34 @@ applyPatchTemplateHaskellCabal ghcFlavor = do
     writeFile "libraries/template-haskell/template-haskell.cabal.in" .
       replace
         (unlines [
-        "    if flag(vendor-filepath)"
-      , "      other-modules:"
-      , "        System.FilePath"
-      , "        System.FilePath.Posix"
-      , "        System.FilePath.Windows"
-      , "      hs-source-dirs: ../filepath ."
-      , "      default-extensions:"
-      , "        ImplicitPrelude"
-      , "    else"
-      , "      build-depends: filepath"
-      , "      hs-source-dirs: ."
-      ])
-      "        filepath"
+            "    if flag(vendor-filepath)"
+          , "      other-modules:"
+          , "        System.FilePath"
+          , "        System.FilePath.Posix"
+          , "        System.FilePath.Windows"
+          , "      hs-source-dirs: ../filepath ."
+          , "      default-extensions:"
+          , "        ImplicitPrelude"
+          , "    else"
+          , "      build-depends: filepath"
+          , "      hs-source-dirs: ."
+          ])
+        "        filepath" .
+      replace
+        (unlines [
+            "    if flag(vendor-filepath)"
+          , "      other-modules:"
+          , "        System.FilePath"
+          , "        System.FilePath.Posix"
+          , "        System.FilePath.Windows"
+          , "      hs-source-dirs: ./vendored-filepath ."
+          , "      default-extensions:"
+          , "        ImplicitPrelude"
+          , "    else"
+          , "      build-depends: filepath"
+          , "      hs-source-dirs: ."
+          ])
+          "        filepath"
       =<< readFile' "libraries/template-haskell/template-haskell.cabal.in"
 
 -- Avoid duplicate symbols with HSghc-heap (see issue

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -7,7 +7,7 @@
 # You can add --resolver xxx to the above command to have the effect
 # of overriding the choice of compiler if desired.
 
-resolver: ghc-9.2.3
+resolver: ghc-9.2.4
 
 ghc-options:
   # Try to be quick.


### PR DESCRIPTION
- ghc-9.4.1 is now released
  - update flavor ghc-9.4.1 to branch ghc-9.4.1-release
  - extend the vendor filepath hack since it's now ever so slightly different to master
- start using 9.2.4 in azure and make it the default in stack-exact.yaml