### PR TITLE
mini-compile example: unconditionally get parser modules through pkg ghc-lib-parser

### DIFF
--- a/examples/mini-compile/src/Main.hs
+++ b/examples/mini-compile/src/Main.hs
@@ -20,51 +20,41 @@ module Main (main) where
 #  define GHC_8101
 #endif
 
--- ghc-lib re-exports the modules of ghc-lib-parser. Before 9.2.1 we
--- couldn't refer to them as being in the ghc-lib package (and instead
--- had to refer to them as being in the ghc-lib-parser package).
-
-#if __GLASGOW_HASKELL__ > 902
-# define GHC_LIB_PARSER_PKG "ghc-lib"
-#else
-# define GHC_LIB_PARSER_PKG "ghc-lib-parser"
-#endif
-
 import "ghc-lib" GHC
 import "ghc-lib" Paths_ghc_lib
 #if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 #  if defined (GHC_MASTER) || defined (GHC_941)
-import GHC_LIB_PARSER_PKG GHC.Driver.Config.Parser
+import "ghc-lib-parser" GHC.Driver.Config.Parser
 #  endif
-import GHC_LIB_PARSER_PKG GHC.Parser.Header
-import GHC_LIB_PARSER_PKG GHC.Unit.Module
-import GHC_LIB_PARSER_PKG GHC.Driver.Session
-import GHC_LIB_PARSER_PKG GHC.Data.StringBuffer
-import GHC_LIB_PARSER_PKG GHC.Utils.Fingerprint
-import GHC_LIB_PARSER_PKG GHC.Utils.Outputable
+import "ghc-lib-parser" GHC.Parser.Header
+import "ghc-lib-parser" GHC.Unit.Module
+import "ghc-lib-parser" GHC.Driver.Session
+import "ghc-lib-parser" GHC.Data.StringBuffer
+import "ghc-lib-parser" GHC.Utils.Fingerprint
+import "ghc-lib-parser" GHC.Utils.Outputable
 #  if !defined (GHC_901)
-import GHC_LIB_PARSER_PKG GHC.Driver.Ppr
+import "ghc-lib-parser" GHC.Driver.Ppr
 #  endif
 #else
-import GHC_LIB_PARSER_PKG HeaderInfo
-import GHC_LIB_PARSER_PKG Module
-import GHC_LIB_PARSER_PKG DynFlags
-import GHC_LIB_PARSER_PKG StringBuffer
-import GHC_LIB_PARSER_PKG Fingerprint
-import GHC_LIB_PARSER_PKG Outputable
+import "ghc-lib-parser" HeaderInfo
+import "ghc-lib-parser" Module
+import "ghc-lib-parser" DynFlags
+import "ghc-lib-parser" StringBuffer
+import "ghc-lib-parser" Fingerprint
+import "ghc-lib-parser" Outputable
 #endif
 #if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
-import GHC_LIB_PARSER_PKG GHC.Settings
-import GHC_LIB_PARSER_PKG GHC.Settings.Config
+import "ghc-lib-parser" GHC.Settings
+import "ghc-lib-parser" GHC.Settings.Config
 #elif defined (GHC_8101)
-import GHC_LIB_PARSER_PKG Config
-import GHC_LIB_PARSER_PKG ToolSettings
+import "ghc-lib-parser" Config
+import "ghc-lib-parser" ToolSettings
 #endif
 #if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
-import GHC_LIB_PARSER_PKG GHC.Platform
+import "ghc-lib-parser" GHC.Platform
 #else
-import GHC_LIB_PARSER_PKG Config
-import GHC_LIB_PARSER_PKG Platform
+import "ghc-lib-parser" Config
+import "ghc-lib-parser" Platform
 #endif
 
 import System.Environment


### PR DESCRIPTION
the `mini-compile` preprocessor logic around `GHC_LIB_PARSER_PKG` is malformed, doesn't make any sense and breaks with ghc-9.4.1. just remove it.