### PR TITLE
make stack-exact.yaml consistent w/recent 9.2.4 resolvers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,8 +59,8 @@ strategy:
     windows-ghc-master-9.2.4:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2022-08-04"
-      stack-yaml: "stack.yaml"
+      resolver: "ghc-9.2.4"
+      stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -30,10 +30,9 @@ extra-deps:
 - clock-0.8.3
 - colour-2.3.6
 - extra-1.7.10
-- mintty-0.1.3 # windows specific (but it does no harm).
-- Win32-2.13.2.0 # new mintty dependency
+- mintty-0.1.4
 - optparse-applicative-0.17.0.0
-- transformers-compat-0.7.1
+- transformers-compat-0.7.2
 # ghc-lib-gen has recently started depending on yaml
 - OneTuple-0.3.1
 - StateVar-1.2.2
@@ -60,14 +59,14 @@ extra-deps:
 - libyaml-0.1.2
 - mono-traversable-1.0.15.3
 - primitive-0.7.4.0
-- resourcet-1.2.5
+- resourcet-1.2.6
 - scientific-0.3.7.0
 - semialign-1.2.0.1
 - semigroupoids-5.3.7
 - strict-0.4.0.1
 - tagged-0.8.6.1
 - text-short-0.1.5
-- th-abstraction-0.4.3.0
+- th-abstraction-0.4.4.0
 - these-1.1.1.1
 - time-compat-1.9.6.1
 - unliftio-core-0.2.0.1
@@ -84,8 +83,13 @@ extra-deps:
 - async-2.2.4
 - temporary-1.3
 - unbounded-delays-0.1.1.1
-- unix-compat-0.5.3
+- unix-compat-0.5.4
 - wcwidth-0.0.2
+
+flags:
+  # Win32 is a compiler lib, the current version is 2.12.0.0.
+  mintty:
+    win32-2-13-1: false
 
 # Packages MUST go at the end, since we append to it during the CI.hs
 # script.


### PR DESCRIPTION
- some `stack-exact.yaml` updates based on what i find in recent stack 9.2.4 resolvers
- i finally worked out why i've struggled with windows builds so much and have corrected `stack-exact.yaml` for it! 🎉 