### PR TITLE
bugfix ghc-lib.cabal: missing bound on ghc-lib-parser

### DIFF
--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -1,4 +1,4 @@
-cabal-version:       >=1.10
+cabal-version:       2.0
 name:                ghc-lib-gen
 version:             0.1.0.0
 synopsis:            Cabal file generator for GHC as a library

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1104,11 +1104,12 @@ ghcLibParserBuildDepends  = commonBuildDepends
 ghcLibBuildDepends :: GhcFlavor -> [String]
 ghcLibBuildDepends ghcFlavor =
   commonBuildDepends ghcFlavor ++
+  [ "stm" | ghcFlavor > Ghc924] ++
   [ "rts"
   , "hpc == 0.6.*"
-  , "ghc-lib-parser"
-  ] ++
-  [ "stm" | ghcFlavor > Ghc924]
+  , "ghc-lib-parser"  -- we rely on this being last (in CI.hs:
+                      -- 'patchConstraints')!
+  ]
 
 -- | This utility factored out to avoid repetion.
 libBinParserModules :: GhcFlavor -> IO ([Cabal], [Cabal], [String])


### PR DESCRIPTION
see https://github.com/commercialhaskell/stackage/issues/6684. ghc-lib-9.4.1.20220807 got on hackage without a bound on `ghc-lib-parser`. 

pr https://github.com/digital-asset/ghc-lib/pull/395 was supposed to be a "small bugfix in bounds patching"  to ensure that the build dependency on `ghc-lib-parser` was constrained to the right version but did not in fact do so.  this pr fixes it right.