### PR TITLE
update azure pipelines, reenable a test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,28 +42,28 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.4.2  |
     # | macOS   | ghc-master      | ghc-9.4.2  |
     # | windows | ghc-master      | ghc-9.4.2  |
     # +---------+-----------------+------------+
 
-    # enable when resolver ghc-9.4.2 exists
-
+    # This pipeline fails at the ghc-9.4.2 install step with
+    # /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
+    # I think this indicates that ubuntu-latest needs an upgrade.
     # linux-ghc-master-9.4.2:
     #   image: "ubuntu-latest"
     #   mode: "--ghc-flavor ghc-master"
     #   resolver: "ghc-9.4.2"
     #   stack-yaml: "stack-exact.yaml"
-    # mac-ghc-master-9.4.2:
-    #   image: "macOS-latest"
-    #   mode: "--ghc-flavor ghc-master"
-    #   resolver: "ghc-9.4.2"
-    #   stack-yaml: "stack-exact.yaml"
-    # windows-ghc-master-9.4.2:
-    #   image: "windows-latest"
-    #   mode: "--ghc-flavor ghc-master"
-    #   resolver: "ghc-9.4.2"
-    #   stack-yaml: "stack-exact.yaml"
+    mac-ghc-master-9.4.2:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.4.2"
+      stack-yaml: "stack-exact.yaml"
+    windows-ghc-master-9.4.2:
+      image: "windows-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.4.2"
+      stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
@@ -136,40 +136,6 @@ strategy:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.2.4"
       resolver: "lts-19.20"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.0.2       | ghc-8.10.7 |
-    # | macOS   | ghc-9.0.2       | ghc-8.8.1  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.0.2-8.10.7:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.0.2"
-      resolver: "lts-18.16"
-      stack-yaml: "stack.yaml"
-    mac-ghc-9.0.2-8.8.1:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.0.2"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-8.10.7      | ghc-8.8.1  |
-    # | macOS   | ghc-8.10.7      | ghc-8.8.1  |
-    # +---------+-----------------+------------+
-    linux-ghc-8.10.7-8.8.1:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-8.10.7"
-      resolver: "nightly-2020-01-08"
-      stack-yaml: "stack.yaml"
-    mac-ghc-8.10.7-8.8.1:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-8.10.7"
-      resolver: "nightly-2020-01-08"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+

--- a/examples/ghc-lib-test-mini-hlint/test/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/test/Main.hs
@@ -37,12 +37,12 @@ main = do
 runTest :: GhcVersion -> String -> Bool
 runTest flavor f =
     -- We need new expect files for master. It's getting tedious to
-    -- maintain this test. Disable running it while we consider what's
-    -- a reasonable amount of effort here.
-  flavor /= GhcMaster &&
+    -- maintain this test. Disable those affected for now.
     (isNothing . stripInfix "Main.hs" $ f) &&
-    ((isNothing . stripInfix "MiniHlintTest_respect_dynamic_pragma.hs" $ f) || (flavor >= Ghc8101)) &&
-    ((isNothing . stripInfix "MiniHlintTest_non_fatal_error.hs" $ f) || (flavor >= Ghc8101))
+    ((isNothing . stripInfix "MiniHlintTest_respect_dynamic_pragma.hs" $ f) || (flavor >= Ghc8101) && (flavor < GhcMaster)) &&
+    ((isNothing . stripInfix "MiniHlintTest_non_fatal_error.hs" $ f) || (flavor >= Ghc8101) && (flavor < GhcMaster)) &&
+    ((isNothing . stripInfix "MiniHlintTest_fatal_error.hs" $ f) || (flavor < GhcMaster)) &&
+    ((isNothing . stripInfix "MiniHlintTest_fail_unknown_pragma.hs" $ f) || (flavor < GhcMaster))
 
 goldenTests :: StackYaml -> Resolver -> GhcFlavor -> [FilePath] -> TestTree
 goldenTests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFlavor ghcFlavor) hsFiles =

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -20,7 +20,7 @@ extra-deps:
 # 'ghc/m4/fptools_happy.m4' which is what bounds ghc above to 1.20.0
 - happy-1.20.0
 # Dependencies for ghc-lib examples:
-- hashable-1.4.0.2
+- hashable-1.4.1.0
 - syb-0.7.2.1
 - uniplate-1.6.13
 - unordered-containers-0.2.19.1
@@ -43,19 +43,20 @@ extra-deps:
 - contravariant-1.5.5
 - integer-logarithms-1.0.3.1
 - random-1.2.1.1
-- split-0.2.3.4
+- split-0.2.3.5
+- generically-0.1
 - vector-algorithms-0.8.0.4
 - bifunctors-5.5.12
 - splitmix-0.1.0.4
 - distributive-0.6.2.1
 - comonad-5.0.8
-- aeson-2.0.3.0
+- aeson-2.1.1.0
 - attoparsec-0.14.4
 - conduit-1.3.4.2
 - data-fix-0.3.2
 - dlist-1.0
 - indexed-traversable-0.1.2
-- indexed-traversable-instances-0.1.1
+- indexed-traversable-instances-0.1.1.1
 - libyaml-0.1.2
 - mono-traversable-1.0.15.3
 - primitive-0.7.4.0


### PR DESCRIPTION
1/3
it seems reasonable to stop testing builds GHC < 9.0.1 builds now. this pr removes those pipelines.

2/3
this pr adds `---ghc-flavor ghc-master`, ghc-9.4.2 pipelines. 

3/3
pr https://github.com/digital-asset/ghc-lib/pull/409 disabled `ghc-lib-mini-hlint-test`s wholesale for `--ghc-flavor ghc-master`. this pr reenables the primary test.