### PR TITLE
enable testing with ghc-9.4.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,92 +41,52 @@ strategy:
 
     # enable when resolver ghc-9.4.3 exists
 
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavor  | GHC        |
+    # +=========+=================+============+
+    # | macOS   | ghc-master      | ghc-9.4.3  |
+    # | windows | ghc-master      | ghc-9.4.3  |
+    # +---------+-----------------+------------+
+    # This pipeline fails at the ghc-9.4.3 install step with
+    # /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
+    # I think this indicates that ubuntu-latest needs an upgrade.
     # linux-ghc-master-9.4.3:
     #   image: "ubuntu-latest"
     #   mode: "--ghc-flavor ghc-master"
     #   resolver: "ghc-9.4.3"
     #   stack-yaml: "stack-exact.yaml"
-    # mac-ghc-master-9.4.3:
-    #   image: "macOS-latest"
-    #   mode: "--ghc-flavor ghc-master"
-    #   resolver: "ghc-9.4.3"
-    #   stack-yaml: "stack-exact.yaml"
-    # windows-ghc-master-9.4.3:
-    #   image: "windows-latest"
-    #   mode: "--ghc-flavor ghc-master"
-    #   resolver: "ghc-9.4.3"
-    #   stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | macOS   | ghc-master      | ghc-9.4.2  |
-    # | windows | ghc-master      | ghc-9.4.2  |
-    # +---------+-----------------+------------+
-
-    # This pipeline fails at the ghc-9.4.2 install step with
-    # /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found
-    # I think this indicates that ubuntu-latest needs an upgrade.
-    # linux-ghc-master-9.4.2:
-    #   image: "ubuntu-latest"
-    #   mode: "--ghc-flavor ghc-master"
-    #   resolver: "ghc-9.4.2"
-    #   stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.4.2:
+    mac-ghc-master-9.4.3:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.4.2"
+      resolver: "ghc-9.4.3"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.4.2:
+    windows-ghc-master-9.4.3:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.4.2"
+      resolver: "ghc-9.4.3"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.2.4  |
-    # | macOS   | ghc-master      | ghc-9.2.4  |
-    # | windows | ghc-master      | ghc-9.2.4  |
+    # | linux   | ghc-9.4.3       | ghc-9.2.5  |
+    # | macOS   | ghc-9.4.3       | ghc-9.2.5  |
+    # | windows | ghc-9.4.3       | ghc-9.2.5  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.2.4:
+    linux-ghc-9.4.3-9.2.5:
       image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2022-08-26"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.2.4:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2022-08-26"
-      stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.2.4:
-      image: "windows-latest"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "nightly-2022-08-26"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.4.2       | ghc-9.2.4  |
-    # | macOS   | ghc-9.4.2       | ghc-9.2.4  |
-    # | windows | ghc-9.4.2       | ghc-9.2.4  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.4.2-9.2.4:
-      image: "ubuntu-latest"
-      mode: "--ghc-flavor ghc-9.4.2"
-      resolver: "nightly-2022-08-04"
+      mode: "--ghc-flavor ghc-9.4.3"
+      resolver: "lts-20.0"
       stack-yaml: "stack.yaml"
-    mac-ghc-9.4.2-9.2.4:
+    mac-ghc-9.4.3-9.2.5:
       image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.4.2"
-      resolver: "nightly-2022-08-04"
+      mode: "--ghc-flavor ghc-9.4.3"
+      resolver: "lts-20.0"
       stack-yaml: "stack.yaml"
-    windows-ghc-9.4.2-9.2.4:
+    windows-ghc-9.4.3-9.2.5:
       image: "windows-latest"
-      mode: "--ghc-flavor ghc-9.4.2"
-      resolver: "nightly-2022-08-04"
+      mode: "--ghc-flavor ghc-9.4.3"
+      resolver: "lts-20.0"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+


### PR DESCRIPTION
this is just a CI update.  ghc-9.4.3 and ghc-9.2.5 resolvers are now listed (see https://github.com/commercialhaskell/stackage-content/blob/master/stack/stack-setup-2.yaml) so enable new builds and clean up old ones