### PR TITLE
pass resolver to ghc-lib-gen

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -358,7 +358,7 @@ buildDists
 
     -- Make and extract an sdist of ghc-lib-parser.
     cmd "cd ghc && git checkout ."
-    stack $ "exec -- ghc-lib-gen ghc --ghc-lib-parser " ++ ghcFlavorOpt ghcFlavor ++ " " ++ cppOpts ghcFlavor
+    stack $ "exec -- ghc-lib-gen ghc --ghc-lib-parser " ++ ghcFlavorOpt ghcFlavor ++ " " ++ cppOpts ghcFlavor ++ " " ++ stackResolverOpt resolver
     patchVersion version "ghc/ghc-lib-parser.cabal"
     mkTarball pkg_ghclib_parser
     renameDirectory pkg_ghclib_parser "ghc-lib-parser"
@@ -366,7 +366,7 @@ buildDists
     cmd "git checkout stack.yaml"
 
     -- Make and extract an sdist of ghc-lib.
-    stack $ "exec -- ghc-lib-gen ghc --ghc-lib " ++ ghcFlavorOpt ghcFlavor ++ " " ++ cppOpts ghcFlavor ++ " " ++ "--skip-init"
+    stack $ "exec -- ghc-lib-gen ghc --ghc-lib " ++ ghcFlavorOpt ghcFlavor ++ " " ++ cppOpts ghcFlavor ++ " " ++ stackResolverOpt resolver ++ " " ++ "--skip-init"
     patchVersion version "ghc/ghc-lib.cabal"
     patchConstraints version "ghc/ghc-lib.cabal"
     mkTarball pkg_ghclib

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -27,6 +27,7 @@ data GhclibgenOpts = GhclibgenOpts {
   , ghclibgenOpts_ghcFlavor :: !GhcFlavor
   , ghclibgenOpts_skipInit :: !Bool
   , ghclibgenOpts_customCppFlags :: ![String]
+  , ghclibgenOpts_stackResolver :: !(Maybe String)
  }
 
 -- | A parser of the "--ghc-lib" target.
@@ -67,6 +68,7 @@ ghclibgenOpts = GhclibgenOpts
         <> help "If enabled, skip initialization steps"
         )
   <*> cppCustomFlagsOpt
+  <*> stackResolverOpt
 
 -- | We might want to factor this out so we can share it with CI.hs
 -- but for now it doesn’t seem worth it and having CI.hs be
@@ -135,4 +137,12 @@ cppCustomFlagsOpt =
     strOption
       ( long "cpp"
      <> help "CPP options to include in the generated cabal file"
+      )
+
+stackResolverOpt :: Parser (Maybe String)
+stackResolverOpt =
+  optional $
+    strOption
+      ( long "resolver"
+     <> help "the prevailing stack resolver"
       )

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -1,5 +1,5 @@
--- Copyright (c) 2019, Digital Asset (Switzerland) GmbH and/or its
--- affiliates. All rights reserved.  SPDX-License-Identifier:
+-- Copyright (c) 2019-2022 Digital Asset (Switzerland) GmbH and/or its
+-- affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 
 module Main(main) where
@@ -23,7 +23,7 @@ main = ghclibgen =<< execParser opts
       )
 
 ghclibgen :: GhclibgenOpts -> IO ()
-ghclibgen (GhclibgenOpts root target ghcFlavor skipInit cppOpts) =
+ghclibgen (GhclibgenOpts root target ghcFlavor skipInit cppOpts resolver) = do
   withCurrentDirectory root $
     case target of
       GhclibParser -> do
@@ -46,7 +46,7 @@ ghclibgen (GhclibgenOpts root target ghcFlavor skipInit cppOpts) =
     init :: GhcFlavor -> IO ()
     init ghcFlavor = do
         applyPatchTemplateHaskellCabal ghcFlavor
-        applyPatchHadrianStackYaml ghcFlavor
+        applyPatchHadrianStackYaml ghcFlavor resolver
         applyPatchHeapClosures ghcFlavor
         applyPatchRtsIncludePaths ghcFlavor
         applyPatchGhcPrim ghcFlavor
@@ -54,7 +54,8 @@ ghclibgen (GhclibgenOpts root target ghcFlavor skipInit cppOpts) =
         -- This line must come before 'generatePrerequisites':
         applyPatchAclocal ghcFlavor -- Do before ./boot && ./configure
         -- This invokes 'stack' strictly configured by
-        -- 'hadrian/stack.yaml'.
+        -- 'hadrian/stack.yaml' (which may be influenced by
+        -- `applyPatchHadrianStackYaml`).
         generatePrerequisites ghcFlavor
         -- Renamings come after 'generatePrerequisites':
         applyPatchDerivedConstants ghcFlavor -- Needs DerivedConstants.h


### PR DESCRIPTION
arrange to pass the prevailing stack resolver from CI.hs to ghc-lib-gen. when available & appropriate use it to rewrite hadrian's stack.yaml to use it. when this happens, it can save significant build time by avoiding a ghc download.