### PR TITLE
hadrian now generates cabal files

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -69,7 +69,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "3c0e379322965aa87b14923f6d8e1ef5cd677925" -- 2022-11-07
+current = "13d627bbd0bc3dd30d672de341aa7f471be0aa2c" -- 2022-11-25
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -202,6 +202,10 @@ dataFiles ghcFlavor =
 
 -- | See 'hadrian/src/Rules/Generate.hs'.
 
+cabalFileDependencies :: GhcFlavor -> [FilePath]
+cabalFileDependencies ghcFlavor =
+  [ f | ghcFlavor > Ghc943, f <- cabalFileBinary : cabalFileLibraries ]
+
 rtsDependencies :: GhcFlavor -> [FilePath]
 rtsDependencies ghcFlavor =
   if ghcFlavor > Ghc925 then
@@ -298,6 +302,7 @@ parsersAndLexers ghcFlavor =
 -- | Cabal "extra-source-files" files for ghc-lib-parser.
 ghcLibParserExtraFiles :: GhcFlavor -> [FilePath]
 ghcLibParserExtraFiles ghcFlavor =
+      cabalFileDependencies ghcFlavor ++
       rtsDependencies ghcFlavor ++
       compilerDependencies ghcFlavor ++
       platformH ghcFlavor ++


### PR DESCRIPTION
"Don't let configure perform trivial substitutions ([#21846](https://gitlab.haskell.org/ghc/ghc/-/issues/21846))" requires we we add the cabal files to the list of things we request hadrian generate.