### PR TITLE
new cabal flag: 'threaded-rts', default 'True'

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1193,17 +1193,26 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         [ "source-repository head"
         , "    type: git"
         , "    location: git@github.com:digital-asset/ghc-lib.git"
-        , ""
-        , "library"
+        ] ++
+        [ "flag threaded-rts"
+        , "  default: True"
+        , "  manual: True"
+        , "  description: Pass -DTHREADED_RTS to the C toolchain"
+        ] ++
+        [ "library"
         , "    default-language:   Haskell2010"
         , "    exposed: False"
         , "    include-dirs:"
+        ] ++ indent2 (ghcLibIncludeDirs ghcFlavor) ++
+        [ "    if flag(threaded-rts)"
+        , "        ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
+        , "        cc-options: -DTHREADED_RTS"
+        , "        cpp-options: -DTHREADED_RTS " <> generateCppOpts ghcFlavor customCppOpts
+        , "    else"
+        , "        ghc-options: -fobject-code -package=ghc-boot-th"
+        , "        cpp-options: " <> generateCppOpts ghcFlavor customCppOpts
         ] ++
-        indent2 (ghcLibIncludeDirs ghcFlavor) ++
-        [ "    ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
-        , "    cc-options: -DTHREADED_RTS"
-        , "    cpp-options: " <> generateCppOpts ghcFlavor customCppOpts
-        , "    if !os(windows)"
+        [ "    if !os(windows)"
         , "        build-depends: unix"
         , "    else"
         , "        build-depends: Win32"
@@ -1229,7 +1238,6 @@ generateCppOpts :: GhcFlavor -> [String] -> String
 generateCppOpts ghcFlavor customCppOpts =
   unwords $
     [ ghcStageDef ghcFlavor
-    , "-DTHREADED_RTS"
     , ghciDef ghcFlavor
     , ghcInGhciDef ghcFlavor
     ]
@@ -1288,20 +1296,29 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
         , "data-dir: " ++ dataDir
         , "data-files:"
         ] ++ indent (dataFiles ghcFlavor) ++
-        [ "extra-source-files:"] ++
-        indent (performExtraFilesSubstitutions ghcFlavor ghcLibParserExtraFiles) ++
+        [ "extra-source-files:"] ++ indent (performExtraFilesSubstitutions ghcFlavor ghcLibParserExtraFiles) ++
         [ "source-repository head"
         , "    type: git"
         , "    location: git@github.com:digital-asset/ghc-lib.git"
-        , ""
-        , "library"
+        ] ++
+        [ "flag threaded-rts"
+        , "  default: True"
+        , "  manual: True"
+        , "  description: Pass -DTHREADED_RTS to the C toolchain"
+        ] ++
+        [ "library"
         , "    default-language:   Haskell2010"
         , "    exposed: False"
         , "    include-dirs:"] ++ indent2 (ghcLibParserIncludeDirs ghcFlavor) ++
-        [ "    ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
-        , "    cc-options: -DTHREADED_RTS"
-        , "    cpp-options: " <> generateCppOpts ghcFlavor customCppOpts
-        , "    if !os(windows)"
+        [ "    if flag(threaded-rts)"
+        , "        ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
+        , "        cc-options: -DTHREADED_RTS"
+        , "        cpp-options: -DTHREADED_RTS " <> generateCppOpts ghcFlavor customCppOpts
+        , "    else"
+        , "        ghc-options: -fobject-code -package=ghc-boot-th"
+        , "        cpp-options: " <> generateCppOpts ghcFlavor customCppOpts
+        ] ++
+        [ "    if !os(windows)"
         , "        build-depends: unix"
         , "    else"
         , "        build-depends: Win32"


### PR DESCRIPTION
new cabal flag to control whether `-DTHREADED_RTS` is passed to the C toolchain. default to `True`. fixes https://github.com/digital-asset/ghc-lib/issues/184. to override the default for a cabal project use like `cabal new-build all --constraint "ghc-lib-parser -threaded-rts" --constraint "ghc-lib -threaded-rts"` or, put the constraints in the project file directly e.g. `
constraints: hlint +ghc-lib, ghc-lib-parser-ex -auto -no-ghc-lib, ghc-lib -threaded-rts, ghc-lib-parser -threaded-rts`. the stack equivalent of that last approach is,
```
flags:
 hlint:
   ghc-lib: true
 ghc-lib-parser:
   threaded-rts: false
 ghc-lib-parser-ex:
   auto: false
   no-ghc-lib: false
```