### PR TITLE
ghc-9.6.1 (alpha)

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -15,6 +15,7 @@ import System.Process.Extra
 import System.Time.Extra
 import System.Info (os, arch)
 import System.Exit
+import System.Environment
 import Data.Maybe
 import Data.List.Extra
 import Data.Time.Clock
@@ -51,6 +52,7 @@ data StackOptions = StackOptions
 
 data GhcFlavor = Da DaFlavor
                | GhcMaster String
+               | Ghc961
                | Ghc944 | Ghc943 | Ghc942 | Ghc941
                | Ghc925 | Ghc924 | Ghc923 | Ghc922 | Ghc921
                | Ghc902 | Ghc901
@@ -69,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "a5bd0eb8dd1d03c54e1b0b476ebbc4cc886d6f19" -- 2022-12-27
+current = "496607fdb77baf12e2fe263104ba5d0d700eee3b" -- 2023-01-14
 
 -- Command line argument generators.
 
@@ -85,6 +87,7 @@ stackResolverOpt = \case
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
+    Ghc961 -> "--ghc-flavor ghc-9.6.1"
     Ghc944 -> "--ghc-flavor ghc-9.4.4"
     Ghc943 -> "--ghc-flavor ghc-9.4.3"
     Ghc942 -> "--ghc-flavor ghc-9.4.2"
@@ -143,6 +146,7 @@ genVersionStr flavor suffix =
     base = case flavor of
       Da {}       -> "8.8.1"
       GhcMaster _ -> "0"
+      Ghc961      -> "9.6.1"
       Ghc944      -> "9.4.4"
       Ghc943      -> "9.4.3"
       Ghc942      -> "9.4.2"
@@ -193,6 +197,7 @@ parseOptions = Options
  where
    readFlavor :: Opts.ReadM GhcFlavor
    readFlavor = Opts.eitherReader $ \case
+       "ghc-9.6.1" -> Right Ghc961
        "ghc-9.4.4" -> Right Ghc944
        "ghc-9.4.3" -> Right Ghc943
        "ghc-9.4.2" -> Right Ghc942
@@ -285,7 +290,10 @@ buildDists
   do
     let stackConfig = fromMaybe "stack.yaml" stackYaml
 
-    -- Clear up any detritus left over from previous runs.
+    -- Clean up old state.
+    isCi <- isJust <$> lookupEnv "GHCLIB_AZURE"
+    -- Avoid https://github.com/commercialhaskell/stack/issues/5866.
+    unless isCi $ stack "clean --full" -- Recursively delete '.stack-work'
     filesInDot <- getDirectoryContents "."
     let lockFiles = filter (isExtensionOf ".lock") filesInDot
         tarBalls  = filter (isExtensionOf ".tar.gz") filesInDot
@@ -314,6 +322,7 @@ buildDists
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
     case ghcFlavor of
+        Ghc961 -> cmd "cd ghc && git checkout ghc-9.6"
         Ghc944 -> cmd "cd ghc && git checkout ghc-9.4.4-release"
         Ghc943 -> cmd "cd ghc && git checkout ghc-9.4.3-release"
         Ghc942 -> cmd "cd ghc && git checkout ghc-9.4.2-release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,10 +34,33 @@ strategy:
     #      | ghc-9.0.*    |  >= 8.8.1   |
     #      | ghc-9.2.*    |  >= 8.10.1  |
     #      | ghc-9.4.1    |  >= 9.0.1   |
-    #      | > ghc-9.4.1  |  >= 9.2.1   |
+    #      | ghc-9.6.1    |  >= 9.2.2   | (9.2.1 is invalid)
+    #      | > ghc-9.6.1  |  >= 9.2.2   |
     #      +--------------+-------------+
     # (the general rule is only the last two compiler versions are
     # supported).
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavor  | GHC        |
+    # +=========+=================+============+
+    # | macOS   | ghc-9.6.1       | ghc-9.4.4  |
+    # | windows | ghc-9.6.1       | ghc-9.4.4  |
+    # +---------+-----------------+------------+
+    linux-ghc-9.6.1-9.4.4:
+      image: "ubuntu-22.04"
+      mode: "--ghc-flavor ghc-9.6.1"
+      resolver: "ghc-9.4.4"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-9.6.1-9.4.4:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-9.6.1"
+      resolver: "ghc-9.4.4"
+      stack-yaml: "stack-exact.yaml"
+    windows-ghc-9.6.1-9.4.4:
+      image: "windows-latest"
+      mode: "--ghc-flavor ghc-9.6.1"
+      resolver: "ghc-9.4.4"
+      stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
@@ -172,5 +195,6 @@ steps:
     displayName: run hlint
     condition: eq( variables['Agent.OS'], 'Linux' )
   - bash: |
+      GHCLIB_AZURE=1;export GHCLIB_AZURE
       stack runhaskell --stack-yaml $(stack-yaml) --resolver $(resolver) --package extra --package optparse-applicative -- CI.hs $(mode)  --stack-yaml $(stack-yaml) --resolver $(resolver)
     displayName: build

--- a/examples/ghc-lib-test-mini-compile/src/Main.hs
+++ b/examples/ghc-lib-test-mini-compile/src/Main.hs
@@ -10,6 +10,8 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib(1,0,0)
 #  define GHC_MASTER
+#elif MIN_VERSION_ghc_lib(9,6,1)
+#  define GHC_961
 #elif MIN_VERSION_ghc_lib(9,4,1)
 #  define GHC_941
 #elif MIN_VERSION_ghc_lib(9,2,1)
@@ -22,8 +24,8 @@ module Main (main) where
 
 import "ghc-lib" GHC
 import "ghc-lib" Paths_ghc_lib
-#if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
-#  if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined (GHC_961) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#  if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941)
 import "ghc-lib-parser" GHC.Driver.Config.Parser
 #  endif
 import "ghc-lib-parser" GHC.Parser.Header
@@ -43,14 +45,14 @@ import "ghc-lib-parser" StringBuffer
 import "ghc-lib-parser" Fingerprint
 import "ghc-lib-parser" Outputable
 #endif
-#if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER)  || defined (GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 import "ghc-lib-parser" GHC.Settings
 import "ghc-lib-parser" GHC.Settings.Config
 #elif defined (GHC_8101)
 import "ghc-lib-parser" Config
 import "ghc-lib-parser" ToolSettings
 #endif
-#if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_961) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Platform
 #else
 import "ghc-lib-parser" Config
@@ -87,27 +89,27 @@ main = do
 mkDynFlags :: String -> String -> IO DynFlags
 mkDynFlags filename s = do
   dirs_to_clean <- newIORef Map.empty
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
        -- Intentionally empty (temp file flags have moved to HscEnv).
 #else
   files_to_clean <- newIORef emptyFilesToClean
 #endif
   next_temp_suffix <- newIORef 0
   let baseFlags =
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
         (defaultDynFlags fakeSettings) {
 #else
         (defaultDynFlags fakeSettings fakeLlvmConfig) {
 #endif
           ghcLink = NoLink
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
         , backend = noBackend
 #elif defined (GHC_941) || defined (GHC_921)
         , backend = NoBackend
 #else
         , hscTarget = HscNothing
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
         -- Intentionally empty (unit related flags have moved to
         -- HscEnv).
 #elif defined (GHC_901)
@@ -115,7 +117,7 @@ mkDynFlags filename s = do
 #else
         , pkgDatabase = Just []
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
        -- Intentionally empty (temp file flags have moved to HscEnv).
 #else
         , dirsToClean = dirs_to_clean
@@ -125,7 +127,7 @@ mkDynFlags filename s = do
 #if defined(DAML_UNIT_IDS)
         , thisInstalledUnitId = toInstalledUnitId (stringToUnitId "daml-prim")
 #else
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
         , homeUnitId_ = toUnitId (stringToUnit "ghc-prim")
 #elif defined (GHC_901)
         , homeUnitId = toUnitId (stringToUnit "ghc-prim")
@@ -138,7 +140,7 @@ mkDynFlags filename s = do
   where
     parsePragmasIntoDynFlags :: String -> String -> DynFlags -> IO DynFlags
     parsePragmasIntoDynFlags filepath contents dflags0 = do
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941)
       let (_, opts) = getOptions (initParserOpts dflags0)
                         (stringToStringBuffer contents) filepath
 #else
@@ -147,7 +149,7 @@ mkDynFlags filename s = do
       (dflags, _, _) <- parseDynamicFilePragma dflags0 opts
       return dflags
 
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
 -- Intentionally empty
 #elif defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
@@ -159,12 +161,12 @@ fakeLlvmConfig = ([], [])
 
 fakeSettings :: Settings
 fakeSettings = Settings
-#if defined (GHC_MASTER) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_961) ||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
   { sGhcNameVersion=ghcNameVersion
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-#  if !defined (GHC_MASTER) && !defined(GHC_941) && !defined (GHC_921)
+#  if !defined (GHC_MASTER) && !defined (GHC_961) && !defined(GHC_941) && !defined (GHC_921)
   , sPlatformConstants=platformConstants
 #  endif
   , sToolSettings=toolSettings
@@ -179,12 +181,12 @@ fakeSettings = Settings
   }
 #endif
   where
-#if defined (GHC_MASTER)  || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER)  || defined (GHC_961)||  defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
     fileSettings = FileSettings {
 #if defined (GHC_8101)
         fileSettings_tmpDir="."
 #else
-#if !defined(GHC_MASTER) && !defined(GHC_941)
+#if !defined(GHC_MASTER) && !defined (GHC_961) && !defined(GHC_941)
         fileSettings_tmpDir=".",
 #endif
        fileSettings_topDir=".",
@@ -199,7 +201,7 @@ fakeSettings = Settings
         toolSettings_opt_P_fingerprint=fingerprint0
       }
     platformMisc = PlatformMisc {
-#if !defined (GHC_MASTER) && !defined(GHC_941) && !defined (GHC_921) && !defined (GHC_901)
+#if !defined (GHC_MASTER) && !defined (GHC_961) && !defined(GHC_941) && !defined (GHC_921) && !defined (GHC_901)
         platformMisc_integerLibraryType=IntegerSimple
 #endif
       }
@@ -210,7 +212,7 @@ fakeSettings = Settings
       }
 #endif
     platform =
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
       genericPlatform
 #else
       Platform{
@@ -237,7 +239,7 @@ fakeSettings = Settings
       , platformUnregisterised=True
       }
 #endif
-#if !defined (GHC_MASTER) && !defined(GHC_941) && !defined (GHC_921)
+#if !defined (GHC_MASTER) && !defined (GHC_961) && !defined(GHC_941) && !defined (GHC_921)
     platformConstants =
        PlatformConstants {
          pc_DYNAMIC_BY_DEFAULT=False

--- a/examples/ghc-lib-test-mini-hlint/src/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/src/Main.hs
@@ -12,6 +12,8 @@ module Main (main) where
 -- We use 0.x for HEAD
 #if !MIN_VERSION_ghc_lib_parser(1,0,0)
 #  define GHC_MASTER
+#elif MIN_VERSION_ghc_lib_parser(9,6,0)
+#  define GHC_961
 #elif MIN_VERSION_ghc_lib_parser(9,4,0)
 #  define GHC_941
 #elif MIN_VERSION_ghc_lib_parser(9,2,0)
@@ -22,26 +24,26 @@ module Main (main) where
 #  define GHC_8101
 #endif
 
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941)
 import "ghc-lib-parser" GHC.Driver.Config.Diagnostic
 import "ghc-lib-parser" GHC.Utils.Logger
 import "ghc-lib-parser" GHC.Driver.Errors
 import "ghc-lib-parser" GHC.Driver.Errors.Types
 import "ghc-lib-parser" GHC.Types.Error
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941)
 import "ghc-lib-parser" GHC.Driver.Config.Parser
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Driver.Ppr
 import "ghc-lib-parser" GHC.Driver.Config
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Hs
 #else
 import "ghc-lib-parser" HsSyn
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 import "ghc-lib-parser" GHC.Settings.Config
 import "ghc-lib-parser" GHC.Driver.Session
 import "ghc-lib-parser" GHC.Data.StringBuffer
@@ -57,7 +59,7 @@ import "ghc-lib-parser" GHC.Parser.Errors.Ppr
 #  endif
 import "ghc-lib-parser" GHC.Types.SrcLoc
 import "ghc-lib-parser" GHC.Utils.Panic
-#  if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#  if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941) || defined (GHC_921)
 import "ghc-lib-parser" GHC.Types.SourceError
 #  else
 import "ghc-lib-parser" GHC.Driver.Types
@@ -81,12 +83,12 @@ import "ghc-lib-parser" HscTypes
 import "ghc-lib-parser" HeaderInfo
 import "ghc-lib-parser" ApiAnnotation
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
 import "ghc-lib-parser" GHC.Settings
 #elif defined (GHC_8101)
 import "ghc-lib-parser" ToolSettings
 #endif
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined(GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 import "ghc-lib-parser" GHC.Platform
 #else
 import "ghc-lib-parser" Bag
@@ -102,12 +104,12 @@ import Data.Generics.Uniplate.Data
 
 fakeSettings :: Settings
 fakeSettings = Settings
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
   { sGhcNameVersion=ghcNameVersion
   , sFileSettings=fileSettings
   , sTargetPlatform=platform
   , sPlatformMisc=platformMisc
-#if !defined (GHC_MASTER) && !defined (GHC_941) && !defined (GHC_921)
+#if !(defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921))
   , sPlatformConstants=platformConstants
 #endif
   , sToolSettings=toolSettings
@@ -121,7 +123,7 @@ fakeSettings = Settings
   }
 #endif
   where
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
     toolSettings = ToolSettings {
       toolSettings_opt_P_fingerprint=fingerprint0
       }
@@ -134,7 +136,7 @@ fakeSettings = Settings
 #endif
 
     platform =
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
       genericPlatform
 #else
       Platform{
@@ -161,11 +163,11 @@ fakeSettings = Settings
       , platformUnregisterised=True
       }
 #endif
-#if !defined(GHC_MASTER) && !defined(GHC_941) && !defined(GHC_921)
+#if !defined(GHC_MASTER) && !defined (GHC_961) && !defined(GHC_941) && !defined(GHC_921)
     platformConstants = PlatformConstants{ pc_DYNAMIC_BY_DEFAULT=False, pc_WORD_SIZE=8 }
 #endif
 
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
 -- Intentionally empty
 #elif defined (GHC_941) || defined (GHC_921) || defined (GHC_901) || defined (GHC_8101)
 fakeLlvmConfig :: LlvmConfig
@@ -181,7 +183,7 @@ parse :: String -> DynFlags -> String -> ParseResult (Located HsModule)
 parse :: String -> DynFlags -> String -> ParseResult (Located (HsModule GhcPs))
 #endif
 parse filename flags str =
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921) || defined (GHC_901)
   unP GHC.Parser.parseModule parseState
 #else
   unP Parser.parseModule parseState
@@ -190,7 +192,7 @@ parse filename flags str =
     location = mkRealSrcLoc (mkFastString filename) 1 1
     buffer = stringToStringBuffer str
     parseState =
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
       initParserState (initParserOpts flags) buffer location
 #else
       mkPState flags buffer location
@@ -199,7 +201,7 @@ parse filename flags str =
 parsePragmasIntoDynFlags :: DynFlags -> FilePath -> String -> IO (Maybe DynFlags)
 parsePragmasIntoDynFlags flags filepath str =
   catchErrors $ do
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined (GHC_961) ||  defined (GHC_941)
     let (_, opts) = getOptions (initParserOpts flags)
                       (stringToStringBuffer str) filepath
 #else
@@ -220,7 +222,7 @@ parsePragmasIntoDynFlags flags filepath str =
       putStrLn $ head
              [ showSDoc flags msg
              | msg <-
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
                       pprMsgEnvelopeBagWithLocDefault . getMessages
 #elif defined (GHC_941)
                       pprMsgEnvelopeBagWithLoc . getMessages
@@ -238,14 +240,14 @@ idNot = mkVarUnqual (fsLit "not")
 
 isNegated :: HsExpr GhcPs -> Bool
 isNegated (HsApp _ (L _ (HsVar _ (L _ id))) _) = id == idNot
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941)
 isNegated (HsPar _ _ (L _ e) _) = isNegated e
 #else
 isNegated (HsPar _ (L _ e)) = isNegated e
 #endif
 isNegated _ = False
 
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
 analyzeExpr :: DynFlags -> LocatedA (HsExpr GhcPs) -> IO ()
 #else
 analyzeExpr :: DynFlags -> Located (HsExpr GhcPs) -> IO ()
@@ -254,7 +256,7 @@ analyzeExpr flags (L loc expr) = do
   case expr of
     HsApp _ (L _ (HsVar _ (L _ id))) (L _ e)
         | id == idNot, isNegated e ->
-#if defined (GHC_MASTER) || defined (GHC_941) || defined (GHC_921)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921)
             putStrLn (showSDoc flags (ppr (locA loc))
 #else
             putStrLn (showSDoc flags (ppr loc)
@@ -263,7 +265,7 @@ analyzeExpr flags (L loc expr) = do
                       ++ "`" ++ showSDoc flags (ppr expr) ++ "'")
     _ -> return ()
 
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
 analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> IO ()
 #elif defined (GHC_941) || defined (GHC_921)
 analyzeModule :: DynFlags -> Located HsModule -> IO ()
@@ -273,7 +275,7 @@ analyzeModule :: DynFlags -> Located HsModule -> ApiAnns -> IO ()
 analyzeModule :: DynFlags -> Located (HsModule GhcPs) -> ApiAnns -> IO ()
 #endif
 analyzeModule flags (L _ modu)
-#if !(defined (GHC_MASTER) || defined(GHC_941) || defined (GHC_921))
+#if !(defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941) || defined (GHC_921))
                                 _ -- ApiAnns
 #endif
  = sequence_ [analyzeExpr flags e | e <- universeBi modu]
@@ -286,14 +288,14 @@ main = do
       s <- readFile' file
       flags <-
         parsePragmasIntoDynFlags
-#if defined(GHC_MASTER)
+#if defined(GHC_MASTER) || defined (GHC_961)
           (defaultDynFlags fakeSettings) file s
 #else
           (defaultDynFlags fakeSettings fakeLlvmConfig) file s
 #endif
       whenJust flags $ \flags ->
          case parse file (flags `gopt_set` Opt_KeepRawTokenStream)s of
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941)
             PFailed s -> report flags $ GhcPsMessage <$> snd (getPsMessages s)
 #elif defined (GHC_921)
             PFailed s -> report flags $ fmap pprError (snd (getMessages s))
@@ -303,7 +305,7 @@ main = do
             PFailed _ loc err -> report flags $ unitBag $ mkPlainErrMsg flags loc err
 #endif
             POk s m -> do
-#if defined (GHC_MASTER) || defined (GHC_941)
+#if defined (GHC_MASTER) || defined (GHC_961) || defined (GHC_941)
               let (wrns, errs) = getPsMessages s
               report flags $ GhcPsMessage <$> wrns
               report flags $ GhcPsMessage <$> errs
@@ -318,13 +320,13 @@ main = do
 #endif
               when (null errs) $
                 analyzeModule flags m
-#if !(defined (GHC_MASTER) || defined(GHC_941) || defined (GHC_921))
+#if !(defined (GHC_MASTER) || defined (GHC_961) || defined(GHC_941) || defined (GHC_921))
                                       (harvestAnns s)
 #endif
     _ -> fail "Exactly one file argument required"
   where
 
-#if defined (GHC_MASTER)
+#if defined (GHC_MASTER) || defined (GHC_961)
     report flags msgs = do
       let opts = initDiagOpts flags
           print_config = initPrintConfig flags
@@ -347,7 +349,7 @@ main = do
 #  endif
         ]
 #endif
-#if !(defined(GHC_MASTER) || defined(GHC_941) || defined (GHC_921))
+#if !(defined(GHC_MASTER) || defined (GHC_961) || defined(GHC_941) || defined (GHC_921))
     harvestAnns pst =
 #  if defined (GHC_901)
         ApiAnns {

--- a/examples/ghc-lib-test-mini-hlint/test/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/test/Main.hs
@@ -36,13 +36,14 @@ main = do
 -- Decide if a file is good to test.
 runTest :: GhcVersion -> String -> Bool
 runTest flavor f =
-    -- We need new expect files for master. It's getting tedious to
-    -- maintain this test. Disable those affected for now.
+    -- We need new expect files for ghc-9.6.1 onwards. It's getting
+    -- super tedious to maintain this test. Disable those affected for
+    -- now.
     (isNothing . stripInfix "Main.hs" $ f) &&
-    ((isNothing . stripInfix "MiniHlintTest_respect_dynamic_pragma.hs" $ f) || (flavor >= Ghc8101) && (flavor < GhcMaster)) &&
-    ((isNothing . stripInfix "MiniHlintTest_non_fatal_error.hs" $ f) || (flavor >= Ghc8101) && (flavor < GhcMaster)) &&
-    ((isNothing . stripInfix "MiniHlintTest_fatal_error.hs" $ f) || (flavor < GhcMaster)) &&
-    ((isNothing . stripInfix "MiniHlintTest_fail_unknown_pragma.hs" $ f) || (flavor < GhcMaster))
+    ((isNothing . stripInfix "MiniHlintTest_respect_dynamic_pragma.hs" $ f) || (flavor >= Ghc8101) && (flavor < Ghc961)) &&
+    ((isNothing . stripInfix "MiniHlintTest_non_fatal_error.hs" $ f) || (flavor >= Ghc8101) && (flavor < Ghc961)) &&
+    ((isNothing . stripInfix "MiniHlintTest_fatal_error.hs" $ f) || (flavor < Ghc961)) &&
+    ((isNothing . stripInfix "MiniHlintTest_fail_unknown_pragma.hs" $ f) || (flavor < Ghc961))
 
 goldenTests :: StackYaml -> Resolver -> GhcFlavor -> [FilePath] -> TestTree
 goldenTests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFlavor ghcFlavor) hsFiles =

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -43,6 +43,7 @@ data GhcVersion = DaGhc881
                 | Ghc942
                 | Ghc943
                 | Ghc944
+                | Ghc961
                 | GhcMaster
   deriving (Eq, Ord, Typeable)
 
@@ -51,6 +52,7 @@ instance Show GhcVersion where
 
 showGhcVersion :: GhcVersion -> String
 showGhcVersion = \case
+    Ghc961 -> "ghc-9.6.1"
     Ghc944 -> "ghc-9.4.4"
     Ghc943 -> "ghc-9.4.3"
     Ghc942 -> "ghc-9.4.2"
@@ -79,6 +81,7 @@ newtype GhcFlavor = GhcFlavor GhcVersion
 
 readFlavor :: String -> Maybe GhcFlavor
 readFlavor = (GhcFlavor <$>) . \case
+    "ghc-9.6.1" -> Just Ghc961
     "ghc-9.4.4" -> Just Ghc944
     "ghc-9.4.3" -> Just Ghc943
     "ghc-9.4.2" -> Just Ghc942

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -408,7 +408,7 @@ calcParserModules ghcFlavor = do
 
 applyPatchTemplateHaskellCabal :: GhcFlavor -> IO ()
 applyPatchTemplateHaskellCabal ghcFlavor = do
-  when (ghcFlavor >= Ghc941 && ghcFlavor < GhcMaster) $ do
+  when (ghcFlavor >= Ghc941 && ghcFlavor < Ghc961) $ do
     -- In
     -- https://gitlab.haskell.org/ghc/ghc/-/commit/b151b65ec469405dcf25f9358e7e99bcc8c2b3ac
     -- (2022/7/05) a temporary change is made to provide for vendoring
@@ -447,7 +447,7 @@ applyPatchTemplateHaskellCabal ghcFlavor = do
           "        filepath"
       =<< readFile' "libraries/template-haskell/template-haskell.cabal.in"
 
-  when (ghcFlavor == GhcMaster) $ do
+  when (ghcFlavor >= Ghc961) $ do
     -- As of
     -- https://gitlab.haskell.org/ghc/ghc/-/commit/9034fadaf641c3821db6e066faaf1a62ed236c13
     -- GHC always relies on vendored filepath sources
@@ -1087,7 +1087,10 @@ baseBounds ghcFlavor =
     Ghc943   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
     Ghc944   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
 
-    GhcMaster -> "base >= 4.16 && < 4.18" -- [ghc-9.2.1, ghc-9.6.1)
+    -- require bytestring >= 0.11.3 which rules out ghc-9.2.1
+    Ghc961   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.7.1)
+
+    GhcMaster -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.7.1)
 
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]
@@ -1100,6 +1103,12 @@ commonBuildDepends ghcFlavor =
         baseBounds ghcFlavor
       ]
     specific
+       | ghcFlavor >= Ghc961  =
+         [
+           "ghc-prim > 0.2 && < 0.11"
+         , "bytestring >= 0.11.3 && < 0.12"
+         , "time >= 1.4 && < 1.13"
+         ]
        | ghcFlavor >= Ghc941  =
          [
            "ghc-prim > 0.2 && < 0.10"

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -96,6 +96,7 @@ data GhcFlavor = DaGhc881
                | Ghc942
                | Ghc943
                | Ghc944
+               | Ghc961
                | GhcMaster
     deriving (Show, Eq, Ord)
 
@@ -107,6 +108,7 @@ ghcFlavorOpt = option readFlavor
 
 readFlavor :: ReadM GhcFlavor
 readFlavor = eitherReader $ \case
+    "ghc-9.6.1" -> Right Ghc961
     "ghc-9.4.4" -> Right Ghc944
     "ghc-9.4.3" -> Right Ghc943
     "ghc-9.4.2" -> Right Ghc942

--- a/ghc-lib-stack-matrix-build-test.sh
+++ b/ghc-lib-stack-matrix-build-test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+flavors=("ghc-master" "ghc-9.6.1")
+resolvers=("ghc-9.4.4" "ghc-9.2.5" "ghc-9.2.2")
+for f in "${flavors[@]}"; do
+    for r in "${resolvers[@]}"; do
+        echo "-- "
+        stack runhaskell --stack-yaml stack-exact.yaml --resolver "$r" --package extra --package optparse-applicative CI.hs -- --ghc-flavor "$f" --stack-yaml stack-exact.yaml --resolver "$r" --no-checkout
+    done
+done

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-08-04 # ghc-9.2.4
+resolver: lts-20.6 # ghc-9.2.5
 
 ghc-options:
   # try and speed up recompilation on the CI server


### PR DESCRIPTION
second try at landing `ghc-9.6.1-alpha`. replaces https://github.com/digital-asset/ghc-lib/pull/423. test-plan: azure, `ghc-lib-stack-matrix-build-test.sh`