### PR TITLE
bump minium base for ghc-master

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "14b5982a3aea351e4b01c5804ebd4d4629ba6bab" -- 2023-01-22
+current = "b69461a06166d2b1c600df87b87656d09122fb7c" -- 2023-01-30
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1090,7 +1090,9 @@ baseBounds ghcFlavor =
     -- require bytestring >= 0.11.3 which rules out ghc-9.2.1
     Ghc961   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.7.1)
 
-    GhcMaster -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.7.1)
+    GhcMaster -- e.g. "9.7.20230119"
+              -- (c.f. 'rts/include/ghc-version.h'')
+      -> "base >= 4.17.0.0 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
 
 -- | Common build dependencies.
 commonBuildDepends :: GhcFlavor -> [String]
@@ -1347,6 +1349,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
         -- https://github.com/digital-asset/ghc-lib/issues/27
         indent2 [ "compiler/cbits/genSym.c" ] ++
         indent2 [ if ghcFlavor >= Ghc901 then "compiler/cbits/cutils.c" else "compiler/parser/cutils.c" ] ++
+        indent2 [ "compiler/cbits/keepCAFsForGHCi.c" | ghcFlavor > Ghc961 ] ++
         [ "    hs-source-dirs:" ] ++
         indent2 (ghcLibParserHsSrcDirs False ghcFlavor lib) ++
         [ "    autogen-modules:" ] ++


### PR DESCRIPTION
### required fix for flavor ghc-master
- [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/08ba87200ff068aa37cac082e61ee7e2d534daf5) requires `compiler/cbits/keepCAFsForGHCI.c` be added to `ghc-lib-parser`
### enhancement
- it's technically not required we build flavor `ghc-master` with build compilers < `ghc-9.4` so let's not