### PR TITLE
simplify mini-hlint tests

### DIFF
--- a/examples/ghc-lib-test-mini-hlint/ghc-lib-test-mini-hlint.cabal
+++ b/examples/ghc-lib-test-mini-hlint/ghc-lib-test-mini-hlint.cabal
@@ -13,7 +13,6 @@ category:            Development
 description:         "ghc-lib-parser" usage example
 
 extra-source-files:  test/*.hs
-                     test/*.expect
 
 executable ghc-lib-test-mini-hlint
   main-is:             Main.hs
@@ -37,5 +36,6 @@ test-suite ghc-lib-test-mini-hlint-test
                      , optparse-applicative
                      , tagged
                      , tasty
-                     , tasty-golden
+                     , tasty-hunit
+                     , utf8-string
                      , ghc-lib-test-utils

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest.expect
@@ -1,1 +1,0 @@
-test/MiniHlintTest.hs:7:18-28 : lint : double negation `not (not x)'

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fail_unknown_pragma.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fail_unknown_pragma.expect
@@ -1,2 +1,0 @@
-test/MiniHlintTest_fail_unknown_pragma.hs:5:14: error:
-    Unsupported extension: Foo

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fatal_error-ghc-master.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fatal_error-ghc-master.expect
@@ -1,6 +1,0 @@
-
-test/MiniHlintTest_fatal_error.hs:11:1: error:
-    parse error on input `{'
-   |
-11 | {
-   | ^

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fatal_error.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_fatal_error.expect
@@ -1,2 +1,0 @@
-test/MiniHlintTest_fatal_error.hs:11:1: error:
-    parse error on input `{'

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_non_fatal_error-ghc-master.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_non_fatal_error-ghc-master.expect
@@ -1,7 +1,0 @@
-
-test/MiniHlintTest_non_fatal_error.hs:8:18: error:
-    Found `qualified' in postpositive position. 
-    Suggested fix: Perhaps you intended to use ImportQualifiedPost
-  |
-8 | import Data.List qualified
-  |                  ^^^^^^^^^

--- a/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_non_fatal_error.expect
+++ b/examples/ghc-lib-test-mini-hlint/test/MiniHlintTest_non_fatal_error.expect
@@ -1,3 +1,0 @@
-test/MiniHlintTest_non_fatal_error.hs:8:18: error:
-    Found `qualified' in postpositive position. 
-    To allow this, enable language extension 'ImportQualifiedPost'

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -78,9 +78,10 @@ extra-deps:
 - yaml-0.11.8.0
 - witherable-0.4.2
 - QuickCheck-2.14.2
-# Dependencies (not already covered) for golden tests
+# Dependencies (not already covered) for tests
+- call-stack-0.4.0
 - tasty-1.4.3
-- tasty-golden-2.3.5
+- tasty-hunit-0.10.0.3
 - typed-process-0.2.10.1
 - utf8-string-1.0.2
 - async-2.2.4


### PR DESCRIPTION
the mini-hlint golden tests were a nuisance to maintain. this replaces them with something equivalent but much simpler.