### PR TITLE
stack-yaml should use resolver >= ghc-9.4

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.6 # ghc-9.2.5
+resolver: nightly-2023-02-04 # ghc-9.4.4
 
 ghc-options:
   # try and speed up recompilation on the CI server


### PR DESCRIPTION
give  `stack.yaml` a 9.4 default resolver so that `stack runhaskell --package extra --package optparse-applicative CI.hs -- --ghc-flavor ghc-master` works