### PR TITLE
pass test binary path to tests

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,10 @@ current = "7612dc713d5a1f108cfd6eb731435b090fbb8809" -- 2023-02-04
 
 -- Command line argument generators.
 
-stackYamlOpt :: Maybe String -> String
+binaryPathOpt :: FilePath -> String
+binaryPathOpt path = "--binary-path " ++ path
+
+stackYamlOpt :: Maybe FilePath -> String
 stackYamlOpt = \case
   Just stackYaml -> "--stack-yaml " ++ stackYaml
   Nothing -> ""
@@ -324,39 +327,7 @@ buildDists
     else do
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
-    case ghcFlavor of
-        Ghc961 -> cmd "cd ghc && git checkout ghc-9.6"
-        Ghc944 -> cmd "cd ghc && git checkout ghc-9.4.4-release"
-        Ghc943 -> cmd "cd ghc && git checkout ghc-9.4.3-release"
-        Ghc942 -> cmd "cd ghc && git checkout ghc-9.4.2-release"
-        Ghc941 -> cmd "cd ghc && git checkout ghc-9.4.1-release"
-        Ghc926 -> cmd "cd ghc && git checkout ghc-9.2.6-release"
-        Ghc925 -> cmd "cd ghc && git checkout ghc-9.2.5-release"
-        Ghc924 -> cmd "cd ghc && git checkout ghc-9.2.4-release"
-        Ghc923 -> cmd "cd ghc && git checkout ghc-9.2.3-release"
-        Ghc922 -> cmd "cd ghc && git checkout ghc-9.2.2-release"
-        Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-release"
-        Ghc901 -> cmd "cd ghc && git checkout ghc-9.0.1-release"
-        Ghc902 -> cmd "cd ghc && git checkout ghc-9.0.2-release"
-        Ghc8101 -> cmd "cd ghc && git checkout ghc-8.10.1-release"
-        Ghc8102 -> cmd "cd ghc && git checkout ghc-8.10.2-release"
-        Ghc8103 -> cmd "cd ghc && git checkout ghc-8.10.3-release"
-        Ghc8104 -> cmd "cd ghc && git checkout ghc-8.10.4-release"
-        Ghc8105 -> cmd "cd ghc && git checkout ghc-8.10.5-release"
-        Ghc8106 -> cmd "cd ghc && git checkout ghc-8.10.6-release"
-        Ghc8107 -> cmd "cd ghc && git checkout ghc-8.10.7-release"
-        Ghc881 -> cmd "cd ghc && git checkout ghc-8.8.1-release"
-        Ghc882 -> cmd "cd ghc && git checkout ghc-8.8.2-release"
-        Ghc883 -> cmd "cd ghc && git checkout ghc-8.8.3-release"
-        Ghc884 -> cmd "cd ghc && git checkout ghc-8.8.4-release"
-        Da DaFlavor { mergeBaseSha, patches, upstream } -> do
-            cmd $ "cd ghc && git checkout " <> mergeBaseSha
-            -- Apply Digital Asset extensions.
-            cmd $ "cd ghc && git remote add upstream " <> upstream
-            cmd "cd ghc && git fetch upstream"
-            cmd $ "cd ghc && git -c user.name=\"Cookie Monster\" -c user.email=cookie.monster@seasame-street.com merge --no-edit " <> unwords patches
-        GhcMaster hash -> cmd $ "cd ghc && git checkout " ++ hash
-    cmd "cd ghc && git submodule update --init --recursive"
+    gitCheckout ghcFlavor
 
     -- Feedback on the compiler used for ghc-lib-gen.
     stack "exec -- ghc --version"
@@ -414,9 +385,9 @@ buildDists
 
     -- Append the libraries and examples to the prevailing stack
     -- configuration file.
-    stackYaml <- readFile' stackConfig
+    stackYamlFileContents <- readFile' stackConfig
     writeFile stackConfig $
-      stackYaml ++
+      stackYamlFileContents ++
       unlines [ "- ghc-lib-parser"
               , "- ghc-lib"
               , "- examples/ghc-lib-test-utils"
@@ -456,10 +427,11 @@ buildDists
     stack $ "--no-terminal --interleaved-output build " ++ ghcOptionsOpt ghcOptions ++ " ghc-lib"
     stack $ "--no-terminal --interleaved-output build " ++ ghcOptionsOpt ghcOptions ++ " ghc-lib-test-mini-hlint ghc-lib-test-mini-compile"
 
-    -- Run tests.
-    let testArguments = "--test-arguments \"" ++ stackYamlOpt (Just $ "../.." </> stackConfig) ++ " " ++ stackResolverOpt resolver ++ " " ++ ghcFlavorOpt ghcFlavor ++ "\""
-    stack $ "test ghc-lib-test-mini-hlint --no-terminal " ++ testArguments
-    stack $ "test ghc-lib-test-mini-compile --no-terminal " ++ testArguments
+    stackInstallRoot <- trimEnd <$> systemOutput_ ("stack path " ++ stackYamlOpt stackYaml ++ " " ++ stackResolverOpt resolver ++ " --local-install-root")
+    let miniHlint = stackInstallRoot </> "bin/ghc-lib-test-mini-hlint"
+    let miniCompile = stackInstallRoot </> "bin/ghc-lib-test-mini-compile"
+    stack $ "test ghc-lib-test-mini-hlint --no-terminal " ++ testArguments miniHlint stackConfig resolver ghcFlavor
+    stack $ "test ghc-lib-test-mini-compile --no-terminal " ++ testArguments miniCompile stackConfig resolver ghcFlavor
 
 #if __GLASGOW_HASKELL__ == 808 && \
     (__GLASGOW_HASKELL_PATCHLEVEL1__ == 1 || __GLASGOW_HASKELL_PATCHLEVEL1__ == 2) && \
@@ -484,6 +456,15 @@ buildDists
     tag -- The return value of type 'IO string'.
 
     where
+      testArguments :: FilePath -> FilePath -> Maybe String -> GhcFlavor -> String
+      testArguments prog stackConfig resolver ghcFlavor =
+        "--test-arguments " ++
+        "\"" ++
+        binaryPathOpt prog ++ " " ++
+        stackYamlOpt (Just $ "../.." </> stackConfig) ++ " " ++
+        stackResolverOpt resolver ++ " " ++ ghcFlavorOpt ghcFlavor ++
+        "\""
+
       ghcOptionsWithHaddock :: Maybe String -> String
       -- Enabling strict haddock mode with -haddock (and for some
       -- build compilers -Winvalid-haddock) has become too tedious.
@@ -568,3 +549,39 @@ buildDists
         whenM (doesPathExist p) $ do
           putStrLn $ "# Removing " ++ p
           removePathForcibly p
+
+      gitCheckout :: GhcFlavor -> IO ()
+      gitCheckout ghcFlavor = do
+        case ghcFlavor of
+          Ghc961 -> cmd "cd ghc && git checkout ghc-9.6"
+          Ghc944 -> cmd "cd ghc && git checkout ghc-9.4.4-release"
+          Ghc943 -> cmd "cd ghc && git checkout ghc-9.4.3-release"
+          Ghc942 -> cmd "cd ghc && git checkout ghc-9.4.2-release"
+          Ghc941 -> cmd "cd ghc && git checkout ghc-9.4.1-release"
+          Ghc926 -> cmd "cd ghc && git checkout ghc-9.2.6-release"
+          Ghc925 -> cmd "cd ghc && git checkout ghc-9.2.5-release"
+          Ghc924 -> cmd "cd ghc && git checkout ghc-9.2.4-release"
+          Ghc923 -> cmd "cd ghc && git checkout ghc-9.2.3-release"
+          Ghc922 -> cmd "cd ghc && git checkout ghc-9.2.2-release"
+          Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-release"
+          Ghc901 -> cmd "cd ghc && git checkout ghc-9.0.1-release"
+          Ghc902 -> cmd "cd ghc && git checkout ghc-9.0.2-release"
+          Ghc8101 -> cmd "cd ghc && git checkout ghc-8.10.1-release"
+          Ghc8102 -> cmd "cd ghc && git checkout ghc-8.10.2-release"
+          Ghc8103 -> cmd "cd ghc && git checkout ghc-8.10.3-release"
+          Ghc8104 -> cmd "cd ghc && git checkout ghc-8.10.4-release"
+          Ghc8105 -> cmd "cd ghc && git checkout ghc-8.10.5-release"
+          Ghc8106 -> cmd "cd ghc && git checkout ghc-8.10.6-release"
+          Ghc8107 -> cmd "cd ghc && git checkout ghc-8.10.7-release"
+          Ghc881 -> cmd "cd ghc && git checkout ghc-8.8.1-release"
+          Ghc882 -> cmd "cd ghc && git checkout ghc-8.8.2-release"
+          Ghc883 -> cmd "cd ghc && git checkout ghc-8.8.3-release"
+          Ghc884 -> cmd "cd ghc && git checkout ghc-8.8.4-release"
+          Da DaFlavor { mergeBaseSha, patches, upstream } -> do
+              cmd $ "cd ghc && git checkout " <> mergeBaseSha
+              -- Apply Digital Asset extensions.
+              cmd $ "cd ghc && git remote add upstream " <> upstream
+              cmd "cd ghc && git fetch upstream"
+              cmd $ "cd ghc && git -c user.name=\"Cookie Monster\" -c user.email=cookie.monster@seasame-street.com merge --no-edit " <> unwords patches
+          GhcMaster hash -> cmd $ "cd ghc && git checkout " ++ hash
+        cmd "cd ghc && git submodule update --init --recursive"

--- a/examples/ghc-lib-test-mini-hlint/test/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/test/Main.hs
@@ -10,56 +10,60 @@ import Test.Tasty.HUnit
 import Data.Proxy
 import Data.Maybe
 import Data.List.Extra
-import Data.ByteString.Lazy.UTF8
 
 import TestUtils
+import System.Process.Extra
+import System.Environment
 
 main :: IO ()
 main = do
+  unsetEnv "GHC_ENVIRONMENT"
   defaultMainWithIngredients ings $
-    askOption $ \ config@(StackYaml _) ->
-      askOption $ \ resolver@(Resolver _) ->
-        askOption $ \ flavor@(GhcFlavor _) -> do
-          tests config resolver flavor
+    askOption $ \ binary@(BinaryPath _) ->
+      askOption $ \ config@(StackYaml _) ->
+        askOption $ \ resolver@(Resolver _) ->
+          askOption $ \ flavor@(GhcFlavor _) -> do
+            tests binary config resolver flavor
   where
     ings =
       includingOptions
-        [ Option (Proxy :: Proxy StackYaml)
+        [ Option (Proxy :: Proxy BinaryPath)
+        , Option (Proxy :: Proxy StackYaml)
         , Option (Proxy :: Proxy Resolver)
         , Option (Proxy :: Proxy GhcFlavor)
         ]
       : defaultIngredients
 
-tests :: StackYaml -> Resolver -> GhcFlavor -> TestTree
-tests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFlavor ghcFlavor) = testGroup " All tests"
-  ([ testCase "MiniHlint.hs" $ testMiniHlintHs stackYaml stackResolver
-   , testCase "MiniHlint_fail_unknown_pragma.hs" $ testMiniHlintFailUnknownPragmaHs stackYaml stackResolver
-   , testCase "MiniHlint_fatal_error.hs" $ testMiniHlintFatalErrorHs stackYaml stackResolver ] ++
-   [ testCase "MiniHlint_non_fatal_error.hs" $ testMiniHlintNonFatalErrorHs stackYaml stackResolver | ghcFlavor >= Ghc8101 ] ++
-   [ testCase "MiniHlint_respect_dynamic_pragma.hs" $ testMiniHlintRespectDynamicPragmaHs stackYaml stackResolver | ghcFlavor >= Ghc8101 ]
+tests :: BinaryPath -> StackYaml -> Resolver -> GhcFlavor -> TestTree
+tests miniHlint _stackYaml@(StackYaml _yaml) _stackResolver@(Resolver _resolver) (GhcFlavor ghcFlavor) = testGroup " All tests"
+  ([ testCase "MiniHlint.hs" $ testMiniHlintHs miniHlint
+   , testCase "MiniHlint_fail_unknown_pragma.hs" $ testMiniHlintFailUnknownPragmaHs miniHlint
+   , testCase "MiniHlint_fatal_error.hs" $ testMiniHlintFatalErrorHs miniHlint ] ++
+   [ testCase "MiniHlint_non_fatal_error.hs" $ testMiniHlintNonFatalErrorHs miniHlint | ghcFlavor >= Ghc8101 ] ++
+   [ testCase "MiniHlint_respect_dynamic_pragma.hs" $ testMiniHlintRespectDynamicPragmaHs miniHlint | ghcFlavor >= Ghc8101 ]
   )
 
-testMiniHlintHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest.hs"
-  assertBool "MiniHlint.hs" (isJust $ stripInfix "lint : double negation" (toString out))
+testMiniHlintHs :: BinaryPath -> IO ()
+testMiniHlintHs (BinaryPath miniHlint) = do
+  out <- systemOutput_ (miniHlint ++ " " ++ "test/MiniHlintTest.hs")
+  assertBool "MiniHlint.hs" (isJust $ stripInfix "lint : double negation" out)
 
-testMiniHlintFailUnknownPragmaHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintFailUnknownPragmaHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_fail_unknown_pragma.hs"
-  assertBool "MiniHlint_fail_unknown_pragma.hs" (isJust $ stripInfix "Unsupported extension" (toString out))
+testMiniHlintFailUnknownPragmaHs :: BinaryPath -> IO ()
+testMiniHlintFailUnknownPragmaHs (BinaryPath miniHlint) = do
+  out <- systemOutput_ (miniHlint ++ " " ++ "test/MiniHlintTest_fail_unknown_pragma.hs")
+  assertBool "MiniHlint_fail_unknown_pragma.hs" (isJust $ stripInfix "Unsupported extension" out)
 
-testMiniHlintFatalErrorHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintFatalErrorHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_fatal_error.hs"
-  assertBool "MiniHlint_fatal_error.hs" (isJust $ stripInfix "parse error" (toString out))
+testMiniHlintFatalErrorHs :: BinaryPath -> IO ()
+testMiniHlintFatalErrorHs (BinaryPath miniHlint) = do
+  out <- systemOutput_ (miniHlint ++ " " ++ "test/MiniHlintTest_fatal_error.hs")
+  assertBool "MiniHlint_fatal_error.hs" (isJust $ stripInfix "parse error" out)
 
-testMiniHlintNonFatalErrorHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintNonFatalErrorHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_non_fatal_error.hs"
-  assertBool "MiniHlint_non_fatal_error.hs" (isJust $ stripInfix "Found `qualified' in postpositive position" (toString out))
+testMiniHlintNonFatalErrorHs :: BinaryPath -> IO ()
+testMiniHlintNonFatalErrorHs (BinaryPath miniHlint) = do
+  out <- systemOutput_ (miniHlint ++ " " ++ "test/MiniHlintTest_non_fatal_error.hs")
+  assertBool "MiniHlint_non_fatal_error.hs" (isJust $ stripInfix "Found `qualified' in postpositive position" out)
 
-testMiniHlintRespectDynamicPragmaHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintRespectDynamicPragmaHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_respect_dynamic_pragma.hs"
-  assertEqual "MiniHlint_respect_dynamic_pragma.hs" (toString out) ""
+testMiniHlintRespectDynamicPragmaHs :: BinaryPath -> IO ()
+testMiniHlintRespectDynamicPragmaHs (BinaryPath miniHlint) = do
+  out <- systemOutput_ (miniHlint ++ " " ++ "test/MiniHlintTest_respect_dynamic_pragma.hs")
+  assertEqual "MiniHlint_respect_dynamic_pragma.hs" out ""  -- True if the the test file parses

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -8,9 +8,6 @@ module TestUtils where
 
 import Test.Tasty.Options
 import Data.Typeable (Typeable)
-import Data.ByteString.Lazy.UTF8
-import Data.Functor
-import System.Process.Extra
 
 newtype StackYaml = StackYaml (Maybe String)
   deriving (Eq, Ord, Typeable)
@@ -136,17 +133,11 @@ instance IsOption Resolver where
   optionName = return "resolver"
   optionHelp = return "Resolver override"
 
-stack :: StackYaml -> Resolver -> String -> IO ByteString
-stack (StackYaml stackYaml) (Resolver resolver) action =
-  systemOutput_ ("stack " ++
-    concatMap (<> " ")
-           [ stackYamlOpt stackYaml
-           , resolverOpt resolver
-           ] ++
-    action) <&> fromString
+newtype BinaryPath = BinaryPath String
+  deriving (Eq, Ord, Typeable)
 
-stackYamlOpt :: Maybe String -> String
-stackYamlOpt = maybe "" ("--stack-yaml " ++)
-
-resolverOpt :: Maybe String -> String
-resolverOpt = maybe "" ("--resolver " ++)
+instance IsOption BinaryPath where
+  defaultValue = BinaryPath "MISSING"
+  parseValue = Just . BinaryPath
+  optionName = return "binary-path"
+  optionHelp = return "Path to test binary"


### PR DESCRIPTION
the test suites ghc-lib-test-mini-hlint-test & ghc-lib-test-mini-compile-test execute programs ghc-lib-test-mini-hlint & ghc-lib-test-mini-compile respectively. until now execution of these programs in their tests have been achieved via `stack run` commands. now rather than this, pass the paths of the executables to the tests enabling them to invoke the programs directly. in this way test execution is made independent of stack.