### PR TITLE
pass test binary path to tests

### DIFF
--- a/examples/ghc-lib-test-mini-hlint/test/Main.hs
+++ b/examples/ghc-lib-test-mini-hlint/test/Main.hs
@@ -10,56 +10,64 @@ import Test.Tasty.HUnit
 import Data.Proxy
 import Data.Maybe
 import Data.List.Extra
-import Data.ByteString.Lazy.UTF8
 
 import TestUtils
+import System.Process.Extra
+import System.IO.Extra
 
 main :: IO ()
 main = do
   defaultMainWithIngredients ings $
-    askOption $ \ config@(StackYaml _) ->
-      askOption $ \ resolver@(Resolver _) ->
-        askOption $ \ flavor@(GhcFlavor _) -> do
-          tests config resolver flavor
+    askOption $ \ cmd@(CommandFile _) ->
+      askOption $ \ config@(StackYaml _) ->
+        askOption $ \ resolver@(Resolver _) ->
+          askOption $ \ flavor@(GhcFlavor _) ->
+              tests cmd config resolver flavor
   where
     ings =
       includingOptions
-        [ Option (Proxy :: Proxy StackYaml)
+        [ Option (Proxy :: Proxy CommandFile)
+        , Option (Proxy :: Proxy StackYaml)
         , Option (Proxy :: Proxy Resolver)
         , Option (Proxy :: Proxy GhcFlavor)
         ]
       : defaultIngredients
 
-tests :: StackYaml -> Resolver -> GhcFlavor -> TestTree
-tests stackYaml@(StackYaml yaml) stackResolver@(Resolver resolver) (GhcFlavor ghcFlavor) = testGroup " All tests"
-  ([ testCase "MiniHlint.hs" $ testMiniHlintHs stackYaml stackResolver
-   , testCase "MiniHlint_fail_unknown_pragma.hs" $ testMiniHlintFailUnknownPragmaHs stackYaml stackResolver
-   , testCase "MiniHlint_fatal_error.hs" $ testMiniHlintFatalErrorHs stackYaml stackResolver ] ++
-   [ testCase "MiniHlint_non_fatal_error.hs" $ testMiniHlintNonFatalErrorHs stackYaml stackResolver | ghcFlavor >= Ghc8101 ] ++
-   [ testCase "MiniHlint_respect_dynamic_pragma.hs" $ testMiniHlintRespectDynamicPragmaHs stackYaml stackResolver | ghcFlavor >= Ghc8101 ]
+tests :: CommandFile -> StackYaml -> Resolver -> GhcFlavor -> TestTree
+tests miniHlint _stackYaml _stackResolver (GhcFlavor ghcFlavor) = testGroup " All tests"
+  ([ testCase "MiniHlint.hs" $ testMiniHlintHs miniHlint
+   , testCase "MiniHlint_fail_unknown_pragma.hs" $ testMiniHlintFailUnknownPragmaHs miniHlint
+   , testCase "MiniHlint_fatal_error.hs" $ testMiniHlintFatalErrorHs miniHlint ] ++
+   [ testCase "MiniHlint_non_fatal_error.hs" $ testMiniHlintNonFatalErrorHs miniHlint | ghcFlavor >= Ghc8101 ] ++
+   [ testCase "MiniHlint_respect_dynamic_pragma.hs" $ testMiniHlintRespectDynamicPragmaHs miniHlint | ghcFlavor >= Ghc8101 ]
   )
 
-testMiniHlintHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest.hs"
-  assertBool "MiniHlint.hs" (isJust $ stripInfix "lint : double negation" (toString out))
+testMiniHlintHs :: CommandFile -> IO ()
+testMiniHlintHs (CommandFile miniHlint) = do
+  cmd <- readFile' miniHlint
+  out <- systemOutput_ $ cmd ++ "test/MiniHlintTest.hs"
+  assertBool "MiniHlint.hs" (isJust $ stripInfix "lint : double negation" out)
 
-testMiniHlintFailUnknownPragmaHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintFailUnknownPragmaHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_fail_unknown_pragma.hs"
-  assertBool "MiniHlint_fail_unknown_pragma.hs" (isJust $ stripInfix "Unsupported extension" (toString out))
+testMiniHlintFailUnknownPragmaHs :: CommandFile -> IO ()
+testMiniHlintFailUnknownPragmaHs (CommandFile miniHlint) = do
+  cmd <- readFile' miniHlint
+  out <- systemOutput_ $ cmd ++ "test/MiniHlintTest_fail_unknown_pragma.hs"
+  assertBool "MiniHlint_fail_unknown_pragma.hs" (isJust $ stripInfix "Unsupported extension" out)
 
-testMiniHlintFatalErrorHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintFatalErrorHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_fatal_error.hs"
-  assertBool "MiniHlint_fatal_error.hs" (isJust $ stripInfix "parse error" (toString out))
+testMiniHlintFatalErrorHs :: CommandFile -> IO ()
+testMiniHlintFatalErrorHs (CommandFile miniHlint) = do
+  cmd <- readFile' miniHlint
+  out <- systemOutput_ $ cmd ++ "test/MiniHlintTest_fatal_error.hs"
+  assertBool "MiniHlint_fatal_error.hs" (isJust $ stripInfix "parse error" out)
 
-testMiniHlintNonFatalErrorHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintNonFatalErrorHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_non_fatal_error.hs"
-  assertBool "MiniHlint_non_fatal_error.hs" (isJust $ stripInfix "Found `qualified' in postpositive position" (toString out))
+testMiniHlintNonFatalErrorHs :: CommandFile -> IO ()
+testMiniHlintNonFatalErrorHs (CommandFile miniHlint) = do
+  cmd <- readFile' miniHlint
+  out <- systemOutput_ $ cmd ++ "test/MiniHlintTest_non_fatal_error.hs"
+  assertBool "MiniHlint_non_fatal_error.hs" (isJust $ stripInfix "Found `qualified' in postpositive position" out)
 
-testMiniHlintRespectDynamicPragmaHs :: StackYaml -> Resolver -> IO ()
-testMiniHlintRespectDynamicPragmaHs stackYaml stackResolver = do
-  out <- stack stackYaml stackResolver $ "--silent --no-terminal exec -- ghc-lib-test-mini-hlint " ++ "test/MiniHlintTest_respect_dynamic_pragma.hs"
-  assertEqual "MiniHlint_respect_dynamic_pragma.hs" (toString out) ""
+testMiniHlintRespectDynamicPragmaHs :: CommandFile -> IO ()
+testMiniHlintRespectDynamicPragmaHs (CommandFile miniHlint) = do
+  cmd <- readFile' miniHlint
+  out <- systemOutput_ $ cmd ++ "test/MiniHlintTest_respect_dynamic_pragma.hs"
+  assertEqual "MiniHlint_respect_dynamic_pragma.hs" out ""  -- True if the the test file parses

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -8,9 +8,6 @@ module TestUtils where
 
 import Test.Tasty.Options
 import Data.Typeable (Typeable)
-import Data.ByteString.Lazy.UTF8
-import Data.Functor
-import System.Process.Extra
 
 newtype StackYaml = StackYaml (Maybe String)
   deriving (Eq, Ord, Typeable)
@@ -136,17 +133,11 @@ instance IsOption Resolver where
   optionName = return "resolver"
   optionHelp = return "Resolver override"
 
-stack :: StackYaml -> Resolver -> String -> IO ByteString
-stack (StackYaml stackYaml) (Resolver resolver) action =
-  systemOutput_ ("stack " ++
-    concatMap (<> " ")
-           [ stackYamlOpt stackYaml
-           , resolverOpt resolver
-           ] ++
-    action) <&> fromString
+newtype CommandFile = CommandFile String
+  deriving (Eq, Ord, Typeable)
 
-stackYamlOpt :: Maybe String -> String
-stackYamlOpt = maybe "" ("--stack-yaml " ++)
-
-resolverOpt :: Maybe String -> String
-resolverOpt = maybe "" ("--resolver " ++)
+instance IsOption CommandFile where
+  defaultValue = CommandFile "MISSING"
+  parseValue = Just . CommandFile
+  optionName = return "test-command"
+  optionHelp = return "File containing a command"


### PR DESCRIPTION
the test suites ghc-lib-test-mini-hlint-test & ghc-lib-test-mini-compile-test execute programs ghc-lib-test-mini-hlint & ghc-lib-test-mini-compile respectively.

until now execution of these programs in these suites has been achieved via `stack run` commands encoded in the tests themselves. now instead, pass along the commands to be run as arguments to the test-suites. the suites just invoke the commands. in this way, test execution is made independent of stack. this in turn enables running the test-suites in cabal projects.