### PR TITLE
add -f to git checkout

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -561,36 +561,36 @@ buildDists
       gitCheckout :: GhcFlavor -> IO ()
       gitCheckout ghcFlavor = do
         case ghcFlavor of
-          Ghc961 -> cmd "cd ghc && git checkout ghc-9.6"
-          Ghc944 -> cmd "cd ghc && git checkout ghc-9.4.4-release"
-          Ghc943 -> cmd "cd ghc && git checkout ghc-9.4.3-release"
-          Ghc942 -> cmd "cd ghc && git checkout ghc-9.4.2-release"
-          Ghc941 -> cmd "cd ghc && git checkout ghc-9.4.1-release"
-          Ghc927 -> cmd "cd ghc && git checkout ghc-9.2.7-release"
-          Ghc926 -> cmd "cd ghc && git checkout ghc-9.2.6-release"
-          Ghc925 -> cmd "cd ghc && git checkout ghc-9.2.5-release"
-          Ghc924 -> cmd "cd ghc && git checkout ghc-9.2.4-release"
-          Ghc923 -> cmd "cd ghc && git checkout ghc-9.2.3-release"
-          Ghc922 -> cmd "cd ghc && git checkout ghc-9.2.2-release"
-          Ghc921 -> cmd "cd ghc && git checkout ghc-9.2.1-release"
-          Ghc901 -> cmd "cd ghc && git checkout ghc-9.0.1-release"
-          Ghc902 -> cmd "cd ghc && git checkout ghc-9.0.2-release"
-          Ghc8101 -> cmd "cd ghc && git checkout ghc-8.10.1-release"
-          Ghc8102 -> cmd "cd ghc && git checkout ghc-8.10.2-release"
-          Ghc8103 -> cmd "cd ghc && git checkout ghc-8.10.3-release"
-          Ghc8104 -> cmd "cd ghc && git checkout ghc-8.10.4-release"
-          Ghc8105 -> cmd "cd ghc && git checkout ghc-8.10.5-release"
-          Ghc8106 -> cmd "cd ghc && git checkout ghc-8.10.6-release"
-          Ghc8107 -> cmd "cd ghc && git checkout ghc-8.10.7-release"
-          Ghc881 -> cmd "cd ghc && git checkout ghc-8.8.1-release"
-          Ghc882 -> cmd "cd ghc && git checkout ghc-8.8.2-release"
-          Ghc883 -> cmd "cd ghc && git checkout ghc-8.8.3-release"
-          Ghc884 -> cmd "cd ghc && git checkout ghc-8.8.4-release"
+          Ghc961 -> cmd "cd ghc && git checkout -f ghc-9.6"
+          Ghc944 -> cmd "cd ghc && git checkout -f ghc-9.4.4-release"
+          Ghc943 -> cmd "cd ghc && git checkout -f ghc-9.4.3-release"
+          Ghc942 -> cmd "cd ghc && git checkout -f ghc-9.4.2-release"
+          Ghc941 -> cmd "cd ghc && git checkout -f ghc-9.4.1-release"
+          Ghc927 -> cmd "cd ghc && git checkout -f ghc-9.2.7-release"
+          Ghc926 -> cmd "cd ghc && git checkout -f ghc-9.2.6-release"
+          Ghc925 -> cmd "cd ghc && git checkout -f ghc-9.2.5-release"
+          Ghc924 -> cmd "cd ghc && git checkout -f ghc-9.2.4-release"
+          Ghc923 -> cmd "cd ghc && git checkout -f ghc-9.2.3-release"
+          Ghc922 -> cmd "cd ghc && git checkout -f ghc-9.2.2-release"
+          Ghc921 -> cmd "cd ghc && git checkout -f ghc-9.2.1-release"
+          Ghc901 -> cmd "cd ghc && git checkout -f ghc-9.0.1-release"
+          Ghc902 -> cmd "cd ghc && git checkout -f ghc-9.0.2-release"
+          Ghc8101 -> cmd "cd ghc && git checkout -f ghc-8.10.1-release"
+          Ghc8102 -> cmd "cd ghc && git checkout -f ghc-8.10.2-release"
+          Ghc8103 -> cmd "cd ghc && git checkout -f ghc-8.10.3-release"
+          Ghc8104 -> cmd "cd ghc && git checkout -f ghc-8.10.4-release"
+          Ghc8105 -> cmd "cd ghc && git checkout -f ghc-8.10.5-release"
+          Ghc8106 -> cmd "cd ghc && git checkout -f ghc-8.10.6-release"
+          Ghc8107 -> cmd "cd ghc && git checkout -f ghc-8.10.7-release"
+          Ghc881 -> cmd "cd ghc && git checkout -f ghc-8.8.1-release"
+          Ghc882 -> cmd "cd ghc && git checkout -f ghc-8.8.2-release"
+          Ghc883 -> cmd "cd ghc && git checkout -f ghc-8.8.3-release"
+          Ghc884 -> cmd "cd ghc && git checkout -f ghc-8.8.4-release"
           Da DaFlavor { mergeBaseSha, patches, upstream } -> do
-              cmd $ "cd ghc && git checkout " <> mergeBaseSha
+              cmd $ "cd ghc && git checkout -f " <> mergeBaseSha
               -- Apply Digital Asset extensions.
               cmd $ "cd ghc && git remote add upstream " <> upstream
               cmd "cd ghc && git fetch upstream"
               cmd $ "cd ghc && git -c user.name=\"Cookie Monster\" -c user.email=cookie.monster@seasame-street.com merge --no-edit " <> unwords patches
-          GhcMaster hash -> cmd $ "cd ghc && git checkout " ++ hash
+          GhcMaster hash -> cmd $ "cd ghc && git checkout -f " ++ hash
         cmd "cd ghc && git submodule update --init --recursive"


### PR DESCRIPTION
up until yesterday, utils/hpc was a regular ghc folder. as of today it's a git sub-repo.  the effect of this is that when switching branches `git checkout` can fail because doing to so would "overwrite untracked files" (in utils/hpc). the simple fix is to `git checkout -f`.