### PR TITLE
pipeline upgrades

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,95 +43,70 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
+    # | linux   | ghc-master      | ghc-9.6.1  |
+    # | macOS   | ghc-master      | ghc-9.6.1  |
+    # | windows | ghc-master      | ghc-9.6.1  |
+    # +---------+-----------------+------------+
+    linux-ghc-master-9.6.1:
+      image: "ubuntu-22.04"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.6.1"
+      stack-yaml: "stack-exact.yaml"
+    mac-ghc-master-9.6.1:
+      image: "macOS-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.6.1"
+      stack-yaml: "stack-exact.yaml"
+    windows-ghc-master-9.6.1:
+      image: "windows-latest"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.6.1"
+      stack-yaml: "stack-exact.yaml"
+
+    # +---------+-----------------+------------+
+    # | OS      | ghc-lib flavor  | GHC        |
+    # +=========+=================+============+
+    # | linux   | ghc-9.6.1       | ghc-9.4.4  |
     # | macOS   | ghc-9.6.1       | ghc-9.4.4  |
     # | windows | ghc-9.6.1       | ghc-9.4.4  |
     # +---------+-----------------+------------+
     linux-ghc-9.6.1-9.4.4:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-9.6.1"
-      resolver: "ghc-9.4.4"
-      stack-yaml: "stack-exact.yaml"
+      resolver: "nightly-2023-03-17"
+      stack-yaml: "stack.yaml"
     mac-ghc-9.6.1-9.4.4:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.6.1"
-      resolver: "ghc-9.4.4"
-      stack-yaml: "stack-exact.yaml"
+      resolver: "nightly-2023-03-17"
+      stack-yaml: "stack.yaml"
     windows-ghc-9.6.1-9.4.4:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.6.1"
-      resolver: "ghc-9.4.4"
-      stack-yaml: "stack-exact.yaml"
+      resolver: "nightly-2023-03-17"
+      stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | macOS   | ghc-master      | ghc-9.4.4  |
-    # | windows | ghc-master      | ghc-9.4.4  |
+    # | linux   | ghc-9.4.4       | ghc-9.2.7  |
+    # | macOS   | ghc-9.4.4       | ghc-9.2.7  |
+    # | windows | ghc-9.4.4       | ghc-9.2.7  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.4.4:
-      image: "ubuntu-22.04"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.4.4"
-      stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.4.4:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.4.4"
-      stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.4.4:
-      image: "windows-latest"
-      mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.4.4"
-      stack-yaml: "stack-exact.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.4.4       | ghc-9.2.6  |
-    # | macOS   | ghc-9.4.4       | ghc-9.2.6  |
-    # | windows | ghc-9.4.4       | ghc-9.2.6  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.4.4-9.2.6:
+    linux-ghc-9.4.4-9.2.7:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-9.4.4"
-      resolver: "lts-20.12"
+      resolver: " lts-20.15"
       stack-yaml: "stack.yaml"
-    mac-ghc-9.4.4-9.2.6:
+    mac-ghc-9.4.4-9.2.7:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.4.4"
-      resolver: "lts-20.12"
+      resolver: " lts-20.15"
       stack-yaml: "stack.yaml"
-    windows-ghc-9.4.4-9.2.6:
+    windows-ghc-9.4.4-9.2.7:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.4.4"
-      resolver: "lts-20.12"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.2.7       | ghc-9.0.2  |
-    # | macOS   | ghc-9.2.5       | ghc-9.0.2  |
-    # | windows | ghc-9.2.7       | ghc-9.0.2  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.2.7-9.0.2:
-      image: "ubuntu-22.04"
-      mode: "--ghc-flavor ghc-9.2.7"
-      resolver: "lts-19.20"
-      stack-yaml: "stack.yaml"
-    # The 9.0.2 resolvers all seem to be missing for macOS. You get
-    # errors like InvalidYaml (Just (YamlException "Yaml file not
-    # found: /Users/runner/work/1/s/lts.19.20"))`. Not a big deal and
-    # I'm not interested in pursuing it further. Just skip it.
-    # mac-ghc-9.2.5-9.0.2:
-    #   image: "macOS-latest"
-    #   mode: "--ghc-flavor ghc-9.2.5"
-    #   resolver: "lts.19.20"
-    #   stack-yaml: "stack.yaml"
-    windows-ghc-9.2.7-9.0.2:
-      image: "windows-latest"
-      mode: "--ghc-flavor ghc-9.2.7"
-      resolver: "lts-19.20"
+      resolver: " lts-20.15"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -7,7 +7,7 @@
 # You can add --resolver xxx to the above command to have the effect
 # of overriding the choice of compiler if desired.
 
-resolver: ghc-9.2.2
+resolver: ghc-9.6.1
 
 ghc-options:
   # Try to be quick.
@@ -91,13 +91,15 @@ extra-deps:
 - wcwidth-0.0.2
 
 flags:
-  # Win32 is a compiler lib, the current version is 2.12.0.1
+  # Win32 is a compiler lib, the version with ghc-9.6.1 is 2.13.3.0
   # (https://www.snoyman.com/base/)
   mintty:
-    win32-2-13-1: false
+    # True for ghc >= 9.6.1 else False.
+    win32-2-13-1: true # Win32 (>=2.13.1)
 
   ansi-terminal:
-    win32-2-13-1: false
+    # True for ghc >= 9.6.1 else False.
+    win32-2-13-1: true # Win32 (>=2.13.1)
 
 # Packages MUST go at the end, since we append to it during the CI.hs
 # script.


### PR DESCRIPTION
get ghc-9.6.1 builds going and drop ghc-9.0. 2 builds