### PR TITLE
update last tested at sha

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ec263a59b886ea616dabce349df7a377d5356dd5" -- 2023-03-11
+current = "6f885e6575eb741556d6e198d1a9dbdadf10307b" -- 2023-03-30
 
 -- Command line argument generators.
 


### PR DESCRIPTION
MR https://gitlab.haskell.org/ghc/ghc/-/merge_requests/8686 changes record update syntax. it's helpful to lock this change into CI.hs for hlint testing.