### PR TITLE
patch reworked plugin initialization

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "4eaf2c2a7682fa9933261f5eb25da9e2333c9608" -- 2023-04-27
+current = "1e6861dd8612d8f71cc4635c4f73f84f316a6c7e" -- 2023-05-10
 
 -- Command line argument generators.
 
@@ -325,15 +325,23 @@ buildDists
     --  git clone https://gitlab.haskell.org/ghc/ghc.git && \
     --      git fetch --tags && git submodule update --init --recursive
     -- and it won't be deleted between runs.
-    if noGhcCheckout then
+    if noGhcCheckout then do
+      cmd "{ cd ghc; git remote remove upstream || true; }"
       cmd "cd ghc && git clean -xdf && git submodule foreach git clean -xdf && git submodule foreach git checkout . && git checkout ."
     else do
       cmd "git clone https://gitlab.haskell.org/ghc/ghc.git"
       cmd "cd ghc && git fetch --tags"
     gitCheckout ghcFlavor
 
+    -- Doing this avoids "Prelude.chr:bad argument" errors
+    -- (https://gitlab.haskell.org/ghc/ghc/-/issues/19452) testing
+    -- locally when later steps try to certain install older versions
+    -- of GHC which enables local testing with `stack runhaskell --stack-yaml stack.yaml --resolver nightly-2020-01-08 --package extra --package optparse-applicative CI.hs -- --da --stack-yaml stack.yaml --resolver nightly-2020-01-08`.
+    stack "exec -- bash -c \"rm -f $HOME/.stack/setup-exe-src/*\""
+
     -- Feedback on the compiler used for ghc-lib-gen.
     stack "exec -- ghc --version"
+
     -- Build ghc-lib-gen. Do this here rather than in the Azure script
     -- so that it's not forgotten when testing this program locally.
     stack "build --no-terminal --ghc-options \"-Wall -Wno-name-shadowing -Werror\""

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -32,6 +32,7 @@ ghclibgen (GhclibgenOpts root patches target ghcFlavor skipInit cppOpts resolver
         applyPatchStage ghcFlavor
         applyPatchHaddockHs ghcFlavor
         applyPatchNoMonoLocalBinds ghcFlavor
+        applyPatchTemplateHaskellLanguageHaskellTHSyntax patches ghcFlavor
         generateGhcLibParserCabal ghcFlavor cppOpts
       Ghclib -> do
         when withInit $ init ghcFlavor

--- a/patches/18a7d03d46706d2217235d26a72e6f1e82c62192-GHC_Driver_Make_hs.patch
+++ b/patches/18a7d03d46706d2217235d26a72e6f1e82c62192-GHC_Driver_Make_hs.patch
@@ -1,0 +1,234 @@
+diff --git a/compiler/GHC/Driver/Make.hs b/compiler/GHC/Driver/Make.hs
+index b7bc05f74a..d72b452d2e 100644
+--- a/compiler/GHC/Driver/Make.hs
++++ b/compiler/GHC/Driver/Make.hs
+@@ -75,7 +75,6 @@ import GHC.Driver.Env
+ import GHC.Driver.Errors
+ import GHC.Driver.Errors.Types
+ import GHC.Driver.Main
+-import GHC.Driver.MakeSem
+ 
+ import GHC.Parser.Header
+ 
+@@ -152,10 +151,10 @@ import GHC.Runtime.Loader
+ import GHC.Rename.Names
+ import GHC.Utils.Constants
+ import GHC.Types.Unique.DFM (udfmRestrictKeysSet)
++import qualified Data.IntSet as I
+ import GHC.Types.Unique
+ import GHC.Iface.Errors.Types
+ 
+-import qualified Data.IntSet as I
+ 
+ -- -----------------------------------------------------------------------------
+ -- Loading the program
+@@ -665,39 +664,11 @@ createBuildPlan mod_graph maybe_top_mod =
+               (vcat [text "Build plan missing nodes:", (text "PLAN:" <+> ppr (sum (map countMods build_plan))), (text "GRAPH:" <+> ppr (length (mgModSummaries' mod_graph )))])
+               build_plan
+ 
+-mkWorkerLimit :: DynFlags -> IO WorkerLimit
+-mkWorkerLimit dflags =
+-  case parMakeCount dflags of
+-    Nothing -> pure $ num_procs 1
+-    Just (ParMakeSemaphore h) -> pure (JSemLimit (SemaphoreName h))
+-    Just ParMakeNumProcessors -> num_procs <$> getNumProcessors
+-    Just (ParMakeThisMany n) -> pure $ num_procs n
+-  where
+-    num_procs x = NumProcessorsLimit (max 1 x)
+-
+-isWorkerLimitSequential :: WorkerLimit -> Bool
+-isWorkerLimitSequential (NumProcessorsLimit x) = x <= 1
+-isWorkerLimitSequential (JSemLimit {})         = False
+-
+--- | This describes what we use to limit the number of jobs, either we limit it
+--- ourselves to a specific number or we have an external parallelism semaphore
+--- limit it for us.
+-data WorkerLimit
+-  = NumProcessorsLimit Int
+-  | JSemLimit
+-    SemaphoreName
+-      -- ^ Semaphore name to use
+-  deriving Eq
+-
+ -- | Generalized version of 'load' which also supports a custom
+ -- 'Messager' (for reporting progress) and 'ModuleGraph' (generally
+ -- produced by calling 'depanal'.
+ load' :: GhcMonad m => Maybe ModIfaceCache -> LoadHowMuch -> Maybe Messager -> ModuleGraph -> m SuccessFlag
+ load' mhmi_cache how_much mHscMessage mod_graph = do
+-    -- In normal usage plugins are initialised already by ghc/Main.hs this is protective
+-    -- for any client who might interact with GHC via load'.
+-    -- See Note [Timing of plugin initialization]
+-    initializeSessionPlugins
+     modifySession $ \hsc_env -> hsc_env { hsc_mod_graph = mod_graph }
+     guessOutputFile
+     hsc_env <- getSession
+@@ -773,12 +744,14 @@ load' mhmi_cache how_much mHscMessage mod_graph = do
+     liftIO $ debugTraceMsg logger 2 (hang (text "Ready for upsweep")
+                                     2 (ppr build_plan))
+ 
+-    worker_limit <- liftIO $ mkWorkerLimit dflags
++    n_jobs <- case parMakeCount (hsc_dflags hsc_env) of
++                    Nothing -> liftIO getNumProcessors
++                    Just n  -> return n
+ 
+     setSession $ hscUpdateHUG (unitEnv_map pruneHomeUnitEnv) hsc_env
+     (upsweep_ok, hsc_env1) <- withDeferredDiagnostics $ do
+       hsc_env <- getSession
+-      liftIO $ upsweep worker_limit hsc_env mhmi_cache mHscMessage (toCache pruned_cache) build_plan
++      liftIO $ upsweep n_jobs hsc_env mhmi_cache mHscMessage (toCache pruned_cache) build_plan
+     setSession hsc_env1
+     case upsweep_ok of
+       Failed -> loadFinish upsweep_ok
+@@ -1063,7 +1036,13 @@ getDependencies direct_deps build_map =
+ type BuildM a = StateT BuildLoopState IO a
+ 
+ 
++-- | Abstraction over the operations of a semaphore which allows usage with the
++--  -j1 case
++data AbstractSem = AbstractSem { acquireSem :: IO ()
++                               , releaseSem :: IO () }
+ 
++withAbstractSem :: AbstractSem -> IO b -> IO b
++withAbstractSem sem = MC.bracket_ (acquireSem sem) (releaseSem sem)
+ 
+ -- | Environment used when compiling a module
+ data MakeEnv = MakeEnv { hsc_env :: !HscEnv -- The basic HscEnv which will be augmented for each module
+@@ -1248,7 +1227,7 @@ withCurrentUnit uid = do
+   local (\env -> env { hsc_env = hscSetActiveUnitId uid (hsc_env env)})
+ 
+ upsweep
+-    :: WorkerLimit -- ^ The number of workers we wish to run in parallel
++    :: Int -- ^ The number of workers we wish to run in parallel
+     -> HscEnv -- ^ The base HscEnv, which is augmented for each module
+     -> Maybe ModIfaceCache -- ^ A cache to incrementally write final interface files to
+     -> Maybe Messager
+@@ -2853,14 +2832,16 @@ label_self thread_name = do
+     CC.labelThread self_tid thread_name
+ 
+ 
+-runPipelines :: WorkerLimit -> HscEnv -> Maybe Messager -> [MakeAction] -> IO ()
++runPipelines :: Int -> HscEnv -> Maybe Messager -> [MakeAction] -> IO ()
+ -- Don't even initialise plugins if there are no pipelines
+ runPipelines _ _ _ [] = return ()
+-runPipelines n_job hsc_env mHscMessager all_pipelines = do
++runPipelines n_job orig_hsc_env mHscMessager all_pipelines = do
+   liftIO $ label_self "main --make thread"
++
++  plugins_hsc_env <- initializePlugins orig_hsc_env
+   case n_job of
+-    NumProcessorsLimit n | n <= 1 -> runSeqPipelines hsc_env mHscMessager all_pipelines
+-    _n -> runParPipelines n_job hsc_env mHscMessager all_pipelines
++    1 -> runSeqPipelines plugins_hsc_env mHscMessager all_pipelines
++    _n -> runParPipelines n_job plugins_hsc_env mHscMessager all_pipelines
+ 
+ runSeqPipelines :: HscEnv -> Maybe Messager -> [MakeAction] -> IO ()
+ runSeqPipelines plugin_hsc_env mHscMessager all_pipelines =
+@@ -2869,38 +2850,16 @@ runSeqPipelines plugin_hsc_env mHscMessager all_pipelines =
+                     , compile_sem = AbstractSem (return ()) (return ())
+                     , env_messager = mHscMessager
+                     }
+-  in runAllPipelines (NumProcessorsLimit 1) env all_pipelines
++  in runAllPipelines 1 env all_pipelines
+ 
+-runNjobsAbstractSem :: Int -> (AbstractSem -> IO a) -> IO a
+-runNjobsAbstractSem n_jobs action = do
+-  compile_sem <- newQSem n_jobs
+-  n_capabilities <- getNumCapabilities
+-  n_cpus <- getNumProcessors
+-  let
+-    asem = AbstractSem (waitQSem compile_sem) (signalQSem compile_sem)
+-    set_num_caps n = unless (n_capabilities /= 1) $ setNumCapabilities n
+-    updNumCapabilities =  do
+-      -- Setting number of capabilities more than
+-      -- CPU count usually leads to high userspace
+-      -- lock contention. #9221
+-      set_num_caps $ min n_jobs n_cpus
+-    resetNumCapabilities = set_num_caps n_capabilities
+-  MC.bracket_ updNumCapabilities resetNumCapabilities $ action asem
+-
+-runWorkerLimit :: WorkerLimit -> (AbstractSem -> IO a) -> IO a
+-runWorkerLimit worker_limit action = case worker_limit of
+-    NumProcessorsLimit n_jobs ->
+-      runNjobsAbstractSem n_jobs action
+-    JSemLimit sem ->
+-      runJSemAbstractSem sem action
+ 
+ -- | Build and run a pipeline
+-runParPipelines :: WorkerLimit -- ^ How to limit work parallelism
+-             -> HscEnv         -- ^ The basic HscEnv which is augmented with specific info for each module
++runParPipelines :: Int              -- ^ How many capabilities to use
++             -> HscEnv           -- ^ The basic HscEnv which is augmented with specific info for each module
+              -> Maybe Messager   -- ^ Optional custom messager to use to report progress
+              -> [MakeAction]  -- ^ The build plan for all the module nodes
+              -> IO ()
+-runParPipelines worker_limit plugin_hsc_env mHscMessager all_pipelines = do
++runParPipelines n_jobs plugin_hsc_env mHscMessager all_pipelines = do
+ 
+ 
+   -- A variable which we write to when an error has happened and we have to tell the
+@@ -2910,23 +2869,39 @@ runParPipelines worker_limit plugin_hsc_env mHscMessager all_pipelines = do
+   -- will add it's LogQueue into this queue.
+   log_queue_queue_var <- newTVarIO newLogQueueQueue
+   -- Thread which coordinates the printing of logs
+-  wait_log_thread <- logThread (hsc_logger plugin_hsc_env) stopped_var log_queue_queue_var
++  wait_log_thread <- logThread n_jobs (length all_pipelines) (hsc_logger plugin_hsc_env) stopped_var log_queue_queue_var
+ 
+ 
+   -- Make the logger thread-safe, in case there is some output which isn't sent via the LogQueue.
+   thread_safe_logger <- liftIO $ makeThreadSafe (hsc_logger plugin_hsc_env)
+   let thread_safe_hsc_env = plugin_hsc_env { hsc_logger = thread_safe_logger }
+ 
+-  runWorkerLimit worker_limit $ \abstract_sem -> do
+-    let env = MakeEnv { hsc_env = thread_safe_hsc_env
+-                      , withLogger = withParLog log_queue_queue_var
+-                      , compile_sem = abstract_sem
+-                      , env_messager = mHscMessager
+-                      }
++  let updNumCapabilities = liftIO $ do
++          n_capabilities <- getNumCapabilities
++          n_cpus <- getNumProcessors
++          -- Setting number of capabilities more than
++          -- CPU count usually leads to high userspace
++          -- lock contention. #9221
++          let n_caps = min n_jobs n_cpus
++          unless (n_capabilities /= 1) $ setNumCapabilities n_caps
++          return n_capabilities
++
++  let resetNumCapabilities orig_n = do
++          liftIO $ setNumCapabilities orig_n
++          atomically $ writeTVar stopped_var True
++          wait_log_thread
++
++  compile_sem <- newQSem n_jobs
++  let abstract_sem = AbstractSem (waitQSem compile_sem) (signalQSem compile_sem)
+     -- Reset the number of capabilities once the upsweep ends.
+-    runAllPipelines worker_limit env all_pipelines
+-    atomically $ writeTVar stopped_var True
+-    wait_log_thread
++  let env = MakeEnv { hsc_env = thread_safe_hsc_env
++                    , withLogger = withParLog log_queue_queue_var
++                    , compile_sem = abstract_sem
++                    , env_messager = mHscMessager
++                    }
++
++  MC.bracket updNumCapabilities resetNumCapabilities $ \_ ->
++    runAllPipelines n_jobs env all_pipelines
+ 
+ withLocalTmpFS :: RunMakeM a -> RunMakeM a
+ withLocalTmpFS act = do
+@@ -2943,11 +2918,10 @@ withLocalTmpFS act = do
+   MC.bracket initialiser finaliser $ \lcl_hsc_env -> local (\env -> env { hsc_env = lcl_hsc_env}) act
+ 
+ -- | Run the given actions and then wait for them all to finish.
+-runAllPipelines :: WorkerLimit -> MakeEnv -> [MakeAction] -> IO ()
+-runAllPipelines worker_limit env acts = do
+-  let single_worker = isWorkerLimitSequential worker_limit
+-      spawn_actions :: IO [ThreadId]
+-      spawn_actions = if single_worker
++runAllPipelines :: Int -> MakeEnv -> [MakeAction] -> IO ()
++runAllPipelines n_jobs env acts = do
++  let spawn_actions :: IO [ThreadId]
++      spawn_actions = if n_jobs == 1
+         then (:[]) <$> (forkIOWithUnmask $ \unmask -> void $ runLoop (\io -> io unmask) env acts)
+         else runLoop forkIOWithUnmask env acts
+ 

--- a/patches/983ce55815f2dd57f84ee86eee97febf7d80b470-libraries_template-haskell_Language_Haskell_TH_Syntax_hs.patch
+++ b/patches/983ce55815f2dd57f84ee86eee97febf7d80b470-libraries_template-haskell_Language_Haskell_TH_Syntax_hs.patch
@@ -1,0 +1,94 @@
+diff --git a/libraries/template-haskell/Language/Haskell/TH/Syntax.hs b/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
+index 92612225e6..513edd5abc 100644
+--- a/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
++++ b/libraries/template-haskell/Language/Haskell/TH/Syntax.hs
+@@ -6,7 +6,6 @@
+              Trustworthy, DeriveFunctor, BangPatterns, RecordWildCards, ImplicitParams #-}
+ 
+ {-# OPTIONS_GHC -fno-warn-inline-rule-shadowing #-}
+-{-# LANGUAGE TemplateHaskellQuotes #-}
+ 
+ -----------------------------------------------------------------------------
+ -- |
+@@ -55,7 +54,7 @@ import Data.Ratio
+ import GHC.CString      ( unpackCString# )
+ import GHC.Generics     ( Generic )
+ import GHC.Types        ( Int(..), Word(..), Char(..), Double(..), Float(..),
+-                          TYPE, RuntimeRep(..), Multiplicity (..) )
++                          TYPE, RuntimeRep(..) )
+ import GHC.Prim         ( Int#, Word#, Char#, Double#, Float#, Addr# )
+ import GHC.Ptr          ( Ptr, plusPtr )
+ import GHC.Lexeme       ( startsVarSym, startsVarId )
+@@ -66,6 +65,7 @@ import Prelude hiding (Applicative(..))
+ import Foreign.ForeignPtr
+ import Foreign.C.String
+ import Foreign.C.Types
++import GHC.Stack
+ 
+ #if __GLASGOW_HASKELL__ >= 901
+ import GHC.Types ( Levity(..) )
+@@ -1067,7 +1067,8 @@ instance Lift (Fixed.Fixed a) where
+     ex <- lift x
+     return (ConE mkFixedName `AppE` ex)
+     where
+-      mkFixedName = 'Fixed.MkFixed
++      mkFixedName =
++        mkNameG DataName "base" "Data.Fixed" "MkFixed"
+ 
+ instance Integral a => Lift (Ratio a) where
+   liftTyped x = unsafeCodeCoerce (lift x)
+@@ -1138,8 +1139,19 @@ instance Lift ByteArray where
+       ptr :: ForeignPtr Word8
+       ptr = ForeignPtr (byteArrayContents# pb) (PlainPtr (unsafeCoerce# pb))
+ 
++
++-- We can't use a TH quote in this module because we're in the template-haskell
++-- package, so we conconct this quite defensive solution to make the correct name
++-- which will work if the package name or module name changes in future.
+ addrToByteArrayName :: Name
+-addrToByteArrayName = 'addrToByteArray
++addrToByteArrayName = helper
++  where
++    helper :: HasCallStack => Name
++    helper =
++      case getCallStack ?callStack of
++        [] -> error "addrToByteArrayName: empty call stack"
++        (_, SrcLoc{..}) : _ -> mkNameG_v srcLocPackage srcLocModule "addrToByteArray"
++
+ 
+ addrToByteArray :: Int -> Addr# -> ByteArray
+ addrToByteArray (I# len) addr = runST $ ST $
+@@ -1359,24 +1371,23 @@ instance (Lift a, Lift b, Lift c, Lift d, Lift e, Lift f, Lift g)
+ 
+ 
+ trueName, falseName :: Name
+-trueName  = 'True
+-falseName = 'False
++trueName  = mkNameG DataName "ghc-prim" "GHC.Types" "True"
++falseName = mkNameG DataName "ghc-prim" "GHC.Types" "False"
+ 
+ nothingName, justName :: Name
+-nothingName = 'Nothing
+-justName    = 'Just
++nothingName = mkNameG DataName "base" "GHC.Maybe" "Nothing"
++justName    = mkNameG DataName "base" "GHC.Maybe" "Just"
+ 
+ leftName, rightName :: Name
+-leftName  = 'Left
+-rightName = 'Right
++leftName  = mkNameG DataName "base" "Data.Either" "Left"
++rightName = mkNameG DataName "base" "Data.Either" "Right"
+ 
+ nonemptyName :: Name
+-nonemptyName = '(:|)
++nonemptyName = mkNameG DataName "base" "GHC.Base" ":|"
+ 
+ oneName, manyName :: Name
+-oneName  = 'One
+-manyName = 'Many
+-
++oneName  = mkNameG DataName "ghc-prim" "GHC.Types" "One"
++manyName = mkNameG DataName "ghc-prim" "GHC.Types" "Many"
+ -----------------------------------------------------
+ --
+ --              Generic Lift implementations


### PR DESCRIPTION
- this [rework plugin initialization commit](https://gitlab.haskell.org/ghc/ghc/-/commit/18a7d03d46706d2217235d26a72e6f1e82c62192) introduces further changes to 'GHC/Driver/Make.hs' in addition to the changes that gave rise to [this PR](https://github.com/digital-asset/ghc-lib/pull/447) so update the patch accordingly
- additionally, [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/983ce55815f2dd57f84ee86eee97febf7d80b470) gives rise to a type mismatch between the package template-haskell and the file `Language.Haskell.TH.Syntax` that appears in ghc-lib-parser (i tried various other approaches to work around this and found out some interesting stuff but for now this keeps things going & appears to be the least thing we can do)
- there's one more thing that i do in this PR which is to `rm $HOME/.stack/setup-exe-src/*` in `CI.hs` (and a related `git remote remove upstream` in the `--no-checkout` case). these things should have no bearing on CI but i worked out enable me to test `--da` builds locally (which i haven't been able to do since forever) 