### PR TITLE
bound applyPatchRtsBytecodes

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "6abf36483a41e50579afcea1497f502875693913" -- 2023-05-23
+current = "f21ce0e4357d527d29595ce32491b02ae3d6a564" -- 2023-05-24
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -699,7 +699,8 @@ applyPatchHaddockHs ghcFlavor = do
 -- instruction codes that this support relies on.
 applyPatchRtsBytecodes :: GhcFlavor -> IO ()
 applyPatchRtsBytecodes ghcFlavor = do
-  when (ghcSeries ghcFlavor >= Ghc92) (
+  let series = ghcSeries ghcFlavor
+  when (series >= Ghc92 && series < Ghc96) (
     writeFile asmHs .
       replace
         "#include \"rts/Bytecodes.h\""


### PR DESCRIPTION
like https://github.com/shayne-fletcher/ghc-lib/pull/178, this patch can be bounded above by ghc-9.6