### PR TITLE
small fix for genPlaceholderModules

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "273ff0c786965de805976e52c8367a036f4f8d95" -- 2023-06-09
+current = "0ff1c5017d7d32cc92ac1ac6f54e12471658d167" -- 2023-06-21
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1426,6 +1426,7 @@ genPlaceholderModule m = do
         l <- T.hGetLine h
         acc <- if "import " `T.isPrefixOf` l then
                  case T.words l of
+                  _import : "::" : _ -> pure acc -- Skip `import :: { ... }` in Parser.y
                   _import : "qualified" : name : _ -> do
                       pure $ T.takeWhile (/= '(') name : acc
                   _import : name : _ -> do


### PR DESCRIPTION
711b1d24df2f6ef524523097855c735aa116262b adds an `import` production to the parser which trips up `parseModuleImports`. add a special case to that function to avoid that.