### PR TITLE
refactor unique commit requires updated make.hs patch

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -71,7 +71,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "fb140f822392cd38ce275451d33e818fcdcab81c" -- 2023-07-05
+current = "53ed21c5d142961848f4b24fa8d5f45d500b9494" -- 2023-07-05
 
 -- Command line argument generators.
 

--- a/patches/9edcb1fb02d799acd4a7d0c145796aecb6e54ea3-GHC_Driver_Make_hs.patch
+++ b/patches/9edcb1fb02d799acd4a7d0c145796aecb6e54ea3-GHC_Driver_Make_hs.patch
@@ -1,5 +1,5 @@
 diff --git a/compiler/GHC/Driver/Make.hs b/compiler/GHC/Driver/Make.hs
-index 08d89aede9..d72b452d2e 100644
+index c3d69347ef..d72b452d2e 100644
 --- a/compiler/GHC/Driver/Make.hs
 +++ b/compiler/GHC/Driver/Make.hs
 @@ -27,7 +27,7 @@
@@ -27,7 +27,7 @@ index 08d89aede9..d72b452d2e 100644
  import GHC.Types.Unique
  import GHC.Iface.Errors.Types
  
--import qualified Data.IntSet as I
+-import qualified GHC.Data.Word64Set as W
  
  -- -----------------------------------------------------------------------------
  -- Loading the program
@@ -301,7 +301,48 @@ index 08d89aede9..d72b452d2e 100644
  
  {- Rehydration, see Note [Rehydrating Modules] -}
  
-@@ -2865,55 +2832,34 @@ label_self thread_name = do
+@@ -2778,7 +2745,6 @@ executeLinkNode hug kn uid deps = do
+                             link (ghcLink dflags)
+                                 (hsc_logger hsc_env')
+                                 (hsc_tmpfs hsc_env')
+-                                (hsc_FC hsc_env')
+                                 (hsc_hooks hsc_env')
+                                 dflags
+                                 (hsc_unit_env hsc_env')
+@@ -2823,12 +2789,12 @@ See test "jspace" for an example which used to trigger this problem.
+ -}
+ 
+ -- See Note [ModuleNameSet, efficiency and space leaks]
+-type ModuleNameSet = M.Map UnitId W.Word64Set
++type ModuleNameSet = M.Map UnitId I.IntSet
+ 
+ addToModuleNameSet :: UnitId -> ModuleName -> ModuleNameSet -> ModuleNameSet
+ addToModuleNameSet uid mn s =
+   let k = (getKey $ getUnique $ mn)
+-  in M.insertWith (W.union) uid (W.singleton k) s
++  in M.insertWith (I.union) uid (I.singleton k) s
+ 
+ -- | Wait for some dependencies to finish and then read from the given MVar.
+ wait_deps_hug :: MVar HomeUnitGraph -> [BuildResult] -> ReaderT MakeEnv (MaybeT IO) (HomeUnitGraph, ModuleNameSet)
+@@ -2839,7 +2805,7 @@ wait_deps_hug hug_var deps = do
+         let -- Restrict to things which are in the transitive closure to avoid retaining
+             -- reference to loop modules which have already been compiled by other threads.
+             -- See Note [ModuleNameSet, efficiency and space leaks]
+-            !new = udfmRestrictKeysSet (homeUnitEnv_hpt hme) (fromMaybe W.empty $ M.lookup  uid module_deps)
++            !new = udfmRestrictKeysSet (homeUnitEnv_hpt hme) (fromMaybe I.empty $ M.lookup  uid module_deps)
+         in hme { homeUnitEnv_hpt = new }
+   return (unitEnv_mapWithKey pruneHomeUnitEnv hug, module_deps)
+ 
+@@ -2854,7 +2820,7 @@ wait_deps (x:xs) = do
+     Nothing -> return (hmis, new_deps)
+     Just hmi -> return (hmi:hmis, new_deps)
+   where
+-    unionModuleNameSet = M.unionWith W.union
++    unionModuleNameSet = M.unionWith I.union
+ 
+ 
+ -- Executing the pipelines
+@@ -2866,55 +2832,34 @@ label_self thread_name = do
      CC.labelThread self_tid thread_name
  
  
@@ -370,7 +411,7 @@ index 08d89aede9..d72b452d2e 100644
  
  
    -- A variable which we write to when an error has happened and we have to tell the
-@@ -2923,24 +2869,39 @@ runParPipelines worker_limit plugin_hsc_env diag_wrapper mHscMessager all_pipeli
+@@ -2924,24 +2869,39 @@ runParPipelines worker_limit plugin_hsc_env diag_wrapper mHscMessager all_pipeli
    -- will add it's LogQueue into this queue.
    log_queue_queue_var <- newTVarIO newLogQueueQueue
    -- Thread which coordinates the printing of logs
@@ -421,7 +462,7 @@ index 08d89aede9..d72b452d2e 100644
  
  withLocalTmpFS :: RunMakeM a -> RunMakeM a
  withLocalTmpFS act = do
-@@ -2957,11 +2918,10 @@ withLocalTmpFS act = do
+@@ -2958,11 +2918,10 @@ withLocalTmpFS act = do
    MC.bracket initialiser finaliser $ \lcl_hsc_env -> local (\env -> env { hsc_env = lcl_hsc_env}) act
  
  -- | Run the given actions and then wait for them all to finish.


### PR DESCRIPTION
9edcb1fb02d799acd4a7d0c145796aecb6e54ea3 necessitates updating the patch of GHC/Driver/Make.hs and also adding 'libraries/container/container/include/container.h' to `cHeaders` and 'libraries/container/container/include/'  to `ghcLibParserIncludeDirs`.