### PR TITLE
add back GHC.Hs.Dump to ghc-lib-parser

### DIFF
--- a/ghc-lib-gen/ghc-lib-parser/ghc-8.10/Main.hs
+++ b/ghc-lib-gen/ghc-lib-parser/ghc-8.10/Main.hs
@@ -16,3 +16,4 @@ import HeaderInfo
 import ApiAnnotation
 import ToolSettings
 import GHC.Platform
+import HsDumpAst

--- a/ghc-lib-gen/ghc-lib-parser/ghc-8.8/Main.hs
+++ b/ghc-lib-gen/ghc-lib-parser/ghc-8.8/Main.hs
@@ -16,3 +16,4 @@ import FastString
 import StringBuffer
 import Bag
 import Platform
+import HsDumpAst

--- a/ghc-lib-gen/ghc-lib-parser/ghc-9.0/Main.hs
+++ b/ghc-lib-gen/ghc-lib-parser/ghc-9.0/Main.hs
@@ -14,3 +14,4 @@ import GHC.Utils.Fingerprint
 import GHC.Settings
 import GHC.Settings.Config
 import GHC.Platform
+import GHC.Hs.Dump

--- a/ghc-lib-gen/ghc-lib-parser/ghc-9.2/Main.hs
+++ b/ghc-lib-gen/ghc-lib-parser/ghc-9.2/Main.hs
@@ -17,3 +17,4 @@ import GHC.Utils.Fingerprint
 import GHC.Utils.Outputable
 import GHC.Utils.Error
 import GHC.Platform
+import GHC.Hs.Dump

--- a/ghc-lib-gen/ghc-lib-parser/ghc-9.4/Main.hs
+++ b/ghc-lib-gen/ghc-lib-parser/ghc-9.4/Main.hs
@@ -23,3 +23,4 @@ import GHC.Settings.Config
 import GHC.Data.StringBuffer
 import GHC.Data.FastString
 import GHC.Platform
+import GHC.Hs.Dump

--- a/ghc-lib-gen/ghc-lib-parser/ghc-9.6/Main.hs
+++ b/ghc-lib-gen/ghc-lib-parser/ghc-9.6/Main.hs
@@ -23,3 +23,4 @@ import GHC.Settings.Config
 import GHC.Data.StringBuffer
 import GHC.Data.FastString
 import GHC.Platform
+import GHC.Hs.Dump


### PR DESCRIPTION
https://github.com/digital-asset/ghc-lib/pull/459 caused a regression that i found with some hlint integration testing. i hope to put a test up soon for ghc-lib that would have caught this earlier.