### PR TITLE
new compiler dep: primop-has-side-effects.hs-incl

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "ee93edfded6ef95e911b7d265feebd1c7f542e8d" -- 2023-07-28
+current = "19dea673c60280fd7b9e92d5df3346292a40e514" -- 2023-08-05
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -189,25 +189,36 @@ rtsDependencies ghcFlavor =
 
 compilerDependencies :: GhcFlavor -> [FilePath]
 compilerDependencies ghcFlavor =
-  (stage0Compiler </>) <$> [
-      "primop-can-fail.hs-incl"
-    , "primop-code-size.hs-incl"
-    , "primop-commutable.hs-incl"
-    , "primop-data-decl.hs-incl"
-    , "primop-fixity.hs-incl"
-    , "primop-has-side-effects.hs-incl"
-    , "primop-list.hs-incl"
-    , "primop-out-of-line.hs-incl"
-    , "primop-primop-info.hs-incl"
-    , "primop-strictness.hs-incl"
-    , "primop-tag.hs-incl"
-    , "primop-vector-tycons.hs-incl"
-    , "primop-vector-tys-exports.hs-incl"
-    , "primop-vector-tys.hs-incl"
-    , "primop-vector-uniques.hs-incl"
-    ] ++
-    [ "primop-docs.hs-incl" | ghcSeries ghcFlavor >= Ghc90 ] ++
-    [ "GHC/Platform/Constants.hs" | ghcSeries ghcFlavor >= Ghc92 ]
+  (stage0Compiler </>) <$>
+  [ "primop-can-fail.hs-incl" | series < Ghc910 ] ++
+  [ "primop-code-size.hs-incl"
+  , "primop-commutable.hs-incl"
+  , "primop-data-decl.hs-incl"
+  , "primop-fixity.hs-incl" ] ++
+  [ if series < Ghc910 then
+      "primop-has-side-effects.hs-incl"
+    else
+      "primop-effects.hs-incl"
+  ] ++
+  [ "primop-list.hs-incl"
+  , "primop-out-of-line.hs-incl"
+  , "primop-primop-info.hs-incl"
+  , "primop-strictness.hs-incl"
+  , "primop-tag.hs-incl"
+  , "primop-vector-tycons.hs-incl"
+  , "primop-vector-tys-exports.hs-incl"
+  , "primop-vector-tys.hs-incl"
+  , "primop-vector-uniques.hs-incl"
+  ] ++
+  [ "primop-docs.hs-incl" | series >= Ghc90 ] ++
+  [f | series >= Ghc910
+     , f <- [ "primop-is-work-free.hs-incl"
+            , "primop-is-cheap.hs-incl"
+            ]
+  ] ++
+  [ "GHC/Platform/Constants.hs" | series >= Ghc92 ]
+  where
+    series = ghcSeries ghcFlavor
 
 platformH :: GhcFlavor -> [FilePath]
 platformH ghcFlavor =


### PR DESCRIPTION
8ba20b2108c419397d53c96b05778615588b75df introduces new compiler dependency 'primops-has-side-effect.hs-incl'.