### PR TITLE
ghc-9.8.1 forward compat

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "19dea673c60280fd7b9e92d5df3346292a40e514" -- 2023-08-05
+current = "a6828173b90dbd276be593c1690aa34317c13c72" -- 2023-08-17
 
 -- Command line argument generators.
 
@@ -619,7 +619,7 @@ buildDists
 
       branch :: GhcFlavor -> String
       branch = \case
-          Ghc981  -> "ghc-9.8.1-alpha1"
+          Ghc981  -> "ghc-9.8" -- track this (not -alpha): it gets backports
           Ghc962  -> "ghc-9.6.2-release"
           Ghc961  -> "ghc-9.6.1-release"
           Ghc946  -> "ghc-9.4.6-release"

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -9,6 +9,7 @@
 #if __GLASGOW_HASKELL__ >= 902
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 #endif
+-- {-# OPTIONS_GHC -Wx-partial #-}
 
 module Ghclibgen (
     applyPatchHeapClosures
@@ -1122,6 +1123,7 @@ baseBounds = \case
     Ghc961   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
     Ghc962   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
 
+    -- base-4.19.0.0, ghc-prim-0.11.0
     Ghc981 -- e.g. "9.7.20230119"
               -- (c.f. 'rts/include/ghc-version.h'')
       -> "base >= 4.17.0.0 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
@@ -1137,23 +1139,33 @@ commonBuildDepends ghcFlavor =
     -- base
     base = [ baseBounds ghcFlavor ]
     specific
+       | ghcSeries ghcFlavor >= GHC_9_8  = [
+           "ghc-prim > 0.2 && < 0.12"
+         , "containers >= 0.6.2.1 && < 0.7"
+         , "bytestring >= 0.11.4 && < 0.12"
+         , "time >= 1.4 && < 1.13"
+         ]
        | ghcSeries ghcFlavor >= GHC_9_6  = [
            "ghc-prim > 0.2 && < 0.11"
+         , "containers >= 0.5 && < 0.7"
          , "bytestring >= 0.11.3 && < 0.12"
          , "time >= 1.4 && < 1.13"
          ]
        | ghcSeries ghcFlavor >= GHC_9_4  = [
            "ghc-prim > 0.2 && < 0.10"
+         , "containers >= 0.5 && < 0.7"
          , "bytestring >= 0.10 && < 0.12"
          , "time >= 1.4 && < 1.13"
          ]
         | ghcSeries ghcFlavor >= GHC_9_2 = [
             "ghc-prim > 0.2 && < 0.9"
+          , "containers >= 0.5 && < 0.7"
           , "bytestring >= 0.9 && < 0.12"
           , "time >= 1.4 && < 1.12"
           ]
         | otherwise = [
             "ghc-prim > 0.2 && < 0.8"
+          , "containers >= 0.5 && < 0.7"
           , "bytestring >= 0.9 && < 0.11"
           , "time >= 1.4 && < 1.10"
           ]
@@ -1162,19 +1174,15 @@ commonBuildDepends ghcFlavor =
             "exceptions == 0.10.*"
           , "parsec"
           ]
-        | ghcSeries ghcFlavor >= GHC_9_8 = [
-            "exceptions == 0.10.*"
-          , "parsec"
+        | otherwise = [
           ]
-        | otherwise = []
     -- shared for all flavors
     shared = [
-        "containers >= 0.5 && < 0.7"
-      , "binary == 0.8.*"
+        "binary == 0.8.*"
       , "filepath >= 1 && < 1.5"
       , "directory >= 1 && < 1.4"
       , "array >= 0.1 && < 0.6"
-      , "deepseq >= 1.4 && < 1.5"
+      , "deepseq >= 1.4 && < 1.6"
       , "pretty == 1.1.*"
       , "transformers >= 0.5 && < 0.7"
       , "process >= 1 && < 1.7"

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -13,8 +13,9 @@ ghc-options:
   # Try to be quick.
   "$everything": -O0 -j
   # hpc: -fno-safe-haskell
+  ghc-lib-gen: -Wno-unrecognised-warning-flags -Wno-x-partial
 
-# allow-newer: true  # For ghc-9.6.2 : Ignoring hpc's bounds on base
+allow-newer: true # aeson's bounds on th-abstraction
 
 extra-deps:
 # Dependencies of ghc-lib-parser & ghc-lib:
@@ -64,6 +65,8 @@ extra-deps:
 - distributive-0.6.2.1
 - comonad-5.0.8
 - aeson-2.1.2.1
+- text-2.0.1
+- parsec-3.1.16.1
 - attoparsec-0.14.4
 - conduit-1.3.5
 - data-fix-0.3.2
@@ -83,7 +86,7 @@ extra-deps:
 - strict-0.5
 - tagged-0.8.7
 - text-short-0.1.5
-- th-abstraction-0.5.0.0
+- th-abstraction-0.6.0.0
 - these-1.2
 - time-compat-1.9.6.1
 - unliftio-core-0.2.1.0


### PR DESCRIPTION
fixes that enable ghc-9.8.1 as a flavor and as a build compiler.