### PR TITLE
use cabal 3.10 for hadrian

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "d6f807ec33573a1c2c0d927749052414d1c23a50" -- 2023-08-26
+current = "0208f1d5d24bc87636469053bf790567d5f3d0e0" -- 2023-09-21
 
 -- Command line argument generators.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,24 +66,24 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-9.8.1       | ghc-9.6.1  |
-    # | macOS   | ghc-9.8.1       | ghc-9.6.1  |
-    # | windows | ghc-9.8.1       | ghc-9.6.1  |
+    # | linux   | ghc-9.8.1       | ghc-9.6.2  |
+    # | macOS   | ghc-9.8.1       | ghc-9.6.2  |
+    # | windows | ghc-9.8.1       | ghc-9.6.2  |
     # +---------+-----------------+------------+
-    linux-ghc-9.8.1-9.6.1:
+    linux-ghc-9.8.1-9.6.2:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-9.8.1"
-      resolver: "ghc-9.6.1"
+      resolver: "ghc-9.6.2"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.8.1-9.6.1:
+    mac-ghc-9.8.1-9.6.2:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-9.8.1"
-      resolver: "ghc-9.6.1"
+      resolver: "ghc-9.6.2"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-9.8.1-9.6.1:
+    windows-ghc-9.8.1-9.6.2:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.8.1"
-      resolver: "ghc-9.6.1"
+      resolver: "ghc-9.6.2"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
@@ -107,29 +107,6 @@ strategy:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-9.6.2"
       resolver: "nightly-2023-03-17"
-      stack-yaml: "stack.yaml"
-
-    # +---------+-----------------+------------+
-    # | OS      | ghc-lib flavor  | GHC        |
-    # +=========+=================+============+
-    # | linux   | ghc-9.4.7       | ghc-9.2.8  |
-    # | macOS   | ghc-9.4.7       | ghc-9.2.8  |
-    # | windows | ghc-9.4.7       | ghc-9.2.8  |
-    # +---------+-----------------+------------+
-    linux-ghc-9.4.7-9.2.8:
-      image: "ubuntu-22.04"
-      mode: "--ghc-flavor ghc-9.4.7"
-      resolver: " lts-20.25"
-      stack-yaml: "stack.yaml"
-    mac-ghc-9.4.7-9.2.8:
-      image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.4.7"
-      resolver: " lts-20.25"
-      stack-yaml: "stack.yaml"
-    windows-ghc-9.4.7-9.2.8:
-      image: "windows-latest"
-      mode: "--ghc-flavor ghc-9.4.7"
-      resolver: " lts-20.25"
       stack-yaml: "stack.yaml"
 
     # +---------+-----------------+------------+

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -970,11 +970,14 @@ applyPatchHadrianStackYaml ghcFlavor resolver = do
   let hadrianStackYaml = "hadrian/stack.yaml"
   config <- Y.decodeFileThrow hadrianStackYaml
   let deps = ["exceptions-0.10.4" | ghcSeries ghcFlavor == GHC_9_0] ++
-        [ file | ghcSeries ghcFlavor >= GHC_9_8
-          , file <- [
+        [ file | ghcSeries ghcFlavor == GHC_9_8
+         , file <- [
                 "Cabal-3.8.1.0"
               , "Cabal-syntax-3.8.1.0"
-              , "unix-2.8.1.1"
+              ]] ++
+        [ file | ghcSeries ghcFlavor >= GHC_9_8
+          , file <- [
+                "unix-2.8.1.1"
               , "directory-1.3.8.1"
               , "process-1.6.17.0"
               , "filepath-1.4.100.4"

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-02-04 # ghc-9.4.4
+resolver: nightly-2023-09-21 # ghc-9.6.2
 
 ghc-options:
   # try and speed up recompilation on the CI server


### PR DESCRIPTION
fa97703474602a079f63e3be4bd48695de33a60d requires modifying our version of hadrian/stack.yaml. also took the chance to cull some old builds and update the default ghc-lib 'stack.yaml' resolver to a 9.6.2 one.