### PR TITLE
more issues with deps

### DIFF
--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -67,7 +67,7 @@ extra-deps:
 - network-uri-2.6.4.2
 - th-compat-0.1.4
 - text-iso8601-0.1
-- text-2.0.2
+- text-2.0.1
 - parsec-3.1.16.1
 - attoparsec-0.14.4
 - conduit-1.3.5


### PR DESCRIPTION
dropping text back to 2.0.1 recovers ghc-9.8 (alpha) build