### PR TITLE
[ghc-9.6.3]: add support for ghc-9.6.3

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -56,7 +56,7 @@ data StackOptions = StackOptions
 data GhcFlavor = Da DaFlavor
                | GhcMaster String
                | Ghc981
-               | Ghc962 | Ghc961
+               | Ghc963 | Ghc962 | Ghc961
                | Ghc947 | Ghc946 | Ghc945 | Ghc944 | Ghc943 | Ghc942 | Ghc941
                | Ghc928 | Ghc927 | Ghc926 | Ghc925 | Ghc924 | Ghc923 | Ghc922 | Ghc921
                | Ghc902 | Ghc901
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "d4b037decd5fcfdff8e32cd9e28d6e9e213592b9" -- 2023-10-08
+current = "08fc27af4731a1cab4f82cfdedbf1dfb5f6fd563" -- 2023-10-13
 
 -- Command line argument generators.
 
@@ -92,6 +92,7 @@ stackResolverOpt = \case
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
     Ghc981 -> "--ghc-flavor ghc-9.8.1"
+    Ghc963 -> "--ghc-flavor ghc-9.6.3"
     Ghc962 -> "--ghc-flavor ghc-9.6.2"
     Ghc961 -> "--ghc-flavor ghc-9.6.1"
     Ghc947 -> "--ghc-flavor ghc-9.4.7"
@@ -159,6 +160,7 @@ genVersionStr flavor suffix =
       Da {}       -> "8.8.1"
       GhcMaster _ -> "0"
       Ghc981      -> "9.8.1"
+      Ghc963      -> "9.6.3"
       Ghc962      -> "9.6.2"
       Ghc961      -> "9.6.1"
       Ghc947      -> "9.4.7"
@@ -217,6 +219,7 @@ parseOptions = Options
    readFlavor :: Opts.ReadM GhcFlavor
    readFlavor = Opts.eitherReader $ \case
        "ghc-9.8.1" -> Right Ghc981
+       "ghc-9.6.3" -> Right Ghc963
        "ghc-9.6.2" -> Right Ghc962
        "ghc-9.6.1" -> Right Ghc961
        "ghc-9.4.7" -> Right Ghc947
@@ -623,6 +626,7 @@ buildDists
       branch :: GhcFlavor -> String
       branch = \case
           Ghc981  -> "ghc-9.8.1-release"
+          Ghc963  -> "ghc-9.6.3-release"
           Ghc962  -> "ghc-9.6.2-release"
           Ghc961  -> "ghc-9.6.1-release"
           Ghc947  -> "ghc-9.4.7-release"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,71 +43,71 @@ strategy:
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-master      | ghc-9.6.2  |
-    # | macOS   | ghc-master      | ghc-9.6.2  |
-    # | windows | ghc-master      | ghc-9.6.2  |
+    # | linux   | ghc-master      | ghc-9.6.3  |
+    # | macOS   | ghc-master      | ghc-9.6.3  |
+    # | windows | ghc-master      | ghc-9.6.3  |
     # +---------+-----------------+------------+
-    linux-ghc-master-9.6.2:
+    linux-ghc-master-9.6.3:
       image: "ubuntu-22.04"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.6.2"
+      resolver: "ghc-9.6.3"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-master-9.6.2:
+    mac-ghc-master-9.6.3:
       image: "macOS-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.6.2"
+      resolver: "ghc-9.6.3"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-master-9.6.2:
+    windows-ghc-master-9.6.3:
       image: "windows-latest"
       mode: "--ghc-flavor ghc-master"
-      resolver: "ghc-9.6.2"
+      resolver: "ghc-9.6.3"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-9.8.1       | ghc-9.6.2  |
-    # | macOS   | ghc-9.8.1       | ghc-9.6.2  |
-    # | windows | ghc-9.8.1       | ghc-9.6.2  |
+    # | linux   | ghc-master      | ghc-9.8.1  |
+    # | macOS   | ghc-master      | ghc-9.8.1  |
+    # | windows | ghc-master      | ghc-9.8.1  |
     # +---------+-----------------+------------+
-    linux-ghc-9.8.1-9.6.2:
+    linux-ghc-master-9.8.1:
       image: "ubuntu-22.04"
-      mode: "--ghc-flavor ghc-9.8.1"
-      resolver: "ghc-9.6.2"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.8.1"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.8.1-9.6.2:
+    mac-ghc-master-9.8.1:
       image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.8.1"
-      resolver: "ghc-9.6.2"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.8.1"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-9.8.1-9.6.2:
+    windows-ghc-master-9.8.1:
       image: "windows-latest"
-      mode: "--ghc-flavor ghc-9.8.1"
-      resolver: "ghc-9.6.2"
+      mode: "--ghc-flavor ghc-master"
+      resolver: "ghc-9.8.1"
       stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |
     # +=========+=================+============+
-    # | linux   | ghc-9.6.2       | ghc-9.4.5  |
-    # | macOS   | ghc-9.6.2       | ghc-9.4.5  |
-    # | windows | ghc-9.6.2       | ghc-9.4.4  |
+    # | linux   | ghc-9.8.1       | ghc-9.6.3  |
+    # | macOS   | ghc-9.8.1       | ghc-9.6.3  |
+    # | windows | ghc-9.8.1       | ghc-9.6.3  |
     # +---------+-----------------+------------+
-    linux-ghc-9.6.2-9.4.5:
+    linux-ghc-9.8.1-9.6.3:
       image: "ubuntu-22.04"
-      mode: "--ghc-flavor ghc-9.6.2"
-      resolver: "ghc-9.4.5"
+      mode: "--ghc-flavor ghc-9.8.1"
+      resolver: "ghc-9.6.3"
       stack-yaml: "stack-exact.yaml"
-    mac-ghc-9.6.2-9.4.5:
+    mac-ghc-9.8.1-9.6.3:
       image: "macOS-latest"
-      mode: "--ghc-flavor ghc-9.6.2"
-      resolver: "ghc-9.4.5"
+      mode: "--ghc-flavor ghc-9.8.1"
+      resolver: "ghc-9.6.3"
       stack-yaml: "stack-exact.yaml"
-    windows-ghc-9.6.2-9.4.4:
+    windows-ghc-9.8.1-9.6.3:
       image: "windows-latest"
-      mode: "--ghc-flavor ghc-9.6.2"
-      resolver: "nightly-2023-03-17"
-      stack-yaml: "stack.yaml"
+      mode: "--ghc-flavor ghc-9.8.1"
+      resolver: "ghc-9.6.3"
+      stack-yaml: "stack-exact.yaml"
 
     # +---------+-----------------+------------+
     # | OS      | ghc-lib flavor  | GHC        |

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -48,6 +48,7 @@ data GhcVersion = DaGhc881
                 | Ghc947
                 | Ghc961
                 | Ghc962
+                | Ghc963
                 | Ghc981
                 | GhcMaster
   deriving (Eq, Ord, Typeable)
@@ -95,6 +96,7 @@ readFlavor = (GhcFlavor <$>) . \case
     -- ghc-9.8
     "ghc-9.8.1" -> Just Ghc981
     -- ghc-9.6
+    "ghc-9.6.3" -> Just Ghc963
     "ghc-9.6.2" -> Just Ghc962
     "ghc-9.6.1" -> Just Ghc961
     -- ghc-9.4

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1135,14 +1135,15 @@ baseBounds = \case
     -- base-4.18.0
     Ghc961   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
     Ghc962   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
+    Ghc963   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
 
     -- base-4.19.0.0, ghc-prim-0.11.0
     Ghc981 -- e.g. "9.8.1.20221009"
               -- (c.f. 'rts/include/ghc-version.h')
-      -> "base >= 4.17.0.0 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
+      -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
     GhcMaster -- e.g. "9.9.20230119"
               -- (c.f. 'rts/include/ghc-version.h')
-      -> "base >= 4.17.0.0 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
+      -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
 
 -- Common build dependencies.
 commonBuildDepends :: GhcFlavor -> Data.List.NonEmpty.NonEmpty String
@@ -1160,7 +1161,7 @@ commonBuildDepends ghcFlavor =
          ]
        | ghcSeries ghcFlavor >= GHC_9_6  = [
            "ghc-prim > 0.2 && < 0.11"
-         , "containers >= 0.5 && < 0.7"
+         , "containers >= 0.6.2.1 && < 0.7"
          , "bytestring >= 0.11.3 && < 0.12"
          , "time >= 1.4 && < 1.13"
          ]

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -14,7 +14,7 @@ data GhcFlavor = DaGhc881
                | Ghc901 | Ghc902
                | Ghc921 | Ghc922 | Ghc923 | Ghc924 | Ghc925 | Ghc926 | Ghc927 | Ghc928
                | Ghc941 | Ghc942 | Ghc943 | Ghc944 | Ghc945 | Ghc946 |  Ghc947
-               | Ghc961 | Ghc962
+               | Ghc961 | Ghc962 | Ghc963
                | Ghc981
                | GhcMaster
   deriving (Show, Eq, Ord)

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -89,6 +89,7 @@ readFlavor = eitherReader $ \case
     "ghc-9.8.1" -> Right Ghc981
 
     -- ghc-9.6
+    "ghc-9.6.3" -> Right Ghc963
     "ghc-9.6.2" -> Right Ghc962
     "ghc-9.6.1" -> Right Ghc961
 


### PR DESCRIPTION
- ghc-9.6.3 was released 9/25/2023 (ghc-lib-9.6.3.20231014 parser sent to hackage today)
- incidentally, introduce ghc-9.8.1 as a build compiler in CI.