### PR TITLE
[ghc-9.4.8]: add new flavor GHC_948

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -57,7 +57,7 @@ data GhcFlavor = Da DaFlavor
                | GhcMaster String
                | Ghc981
                | Ghc963 | Ghc962 | Ghc961
-               | Ghc947 | Ghc946 | Ghc945 | Ghc944 | Ghc943 | Ghc942 | Ghc941
+               | Ghc948 | Ghc947 | Ghc946 | Ghc945 | Ghc944 | Ghc943 | Ghc942 | Ghc941
                | Ghc928 | Ghc927 | Ghc926 | Ghc925 | Ghc924 | Ghc923 | Ghc922 | Ghc921
                | Ghc902 | Ghc901
                | Ghc8107 | Ghc8106 | Ghc8105 | Ghc8104 | Ghc8103 | Ghc8102 | Ghc8101 | Ghc881
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "08fc27af4731a1cab4f82cfdedbf1dfb5f6fd563" -- 2023-10-13
+current = "6dbab1808bfbe484b3fb396aab1d105314f918d8" -- 2023-11-10
 
 -- Command line argument generators.
 
@@ -95,6 +95,7 @@ ghcFlavorOpt = \case
     Ghc963 -> "--ghc-flavor ghc-9.6.3"
     Ghc962 -> "--ghc-flavor ghc-9.6.2"
     Ghc961 -> "--ghc-flavor ghc-9.6.1"
+    Ghc948 -> "--ghc-flavor ghc-9.4.8"
     Ghc947 -> "--ghc-flavor ghc-9.4.7"
     Ghc946 -> "--ghc-flavor ghc-9.4.6"
     Ghc945 -> "--ghc-flavor ghc-9.4.5"
@@ -163,6 +164,7 @@ genVersionStr flavor suffix =
       Ghc963      -> "9.6.3"
       Ghc962      -> "9.6.2"
       Ghc961      -> "9.6.1"
+      Ghc948      -> "9.4.8"
       Ghc947      -> "9.4.7"
       Ghc946      -> "9.4.6"
       Ghc945      -> "9.4.5"
@@ -222,6 +224,7 @@ parseOptions = Options
        "ghc-9.6.3" -> Right Ghc963
        "ghc-9.6.2" -> Right Ghc962
        "ghc-9.6.1" -> Right Ghc961
+       "ghc-9.4.8" -> Right Ghc948
        "ghc-9.4.7" -> Right Ghc947
        "ghc-9.4.6" -> Right Ghc946
        "ghc-9.4.5" -> Right Ghc945
@@ -629,6 +632,7 @@ buildDists
           Ghc963  -> "ghc-9.6.3-release"
           Ghc962  -> "ghc-9.6.2-release"
           Ghc961  -> "ghc-9.6.1-release"
+          Ghc948  -> "ghc-9.4.8-release"
           Ghc947  -> "ghc-9.4.7-release"
           Ghc946  -> "ghc-9.4.6-release"
           Ghc945  -> "ghc-9.4.5-release"

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -46,6 +46,7 @@ data GhcVersion = DaGhc881
                 | Ghc945
                 | Ghc946
                 | Ghc947
+                | Ghc948
                 | Ghc961
                 | Ghc962
                 | Ghc963
@@ -60,6 +61,7 @@ showGhcVersion :: GhcVersion -> String
 showGhcVersion = \case
     Ghc981 -> "ghc-9.8.1"
     Ghc961 -> "ghc-9.6.1"
+    Ghc948 -> "ghc-9.4.8"
     Ghc947 -> "ghc-9.4.7"
     Ghc946 -> "ghc-9.4.6"
     Ghc945 -> "ghc-9.4.5"
@@ -100,6 +102,7 @@ readFlavor = (GhcFlavor <$>) . \case
     "ghc-9.6.2" -> Just Ghc962
     "ghc-9.6.1" -> Just Ghc961
     -- ghc-9.4
+    "ghc-9.4.8" -> Just Ghc948
     "ghc-9.4.7" -> Just Ghc947
     "ghc-9.4.6" -> Just Ghc946
     "ghc-9.4.5" -> Just Ghc945

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1130,6 +1130,7 @@ baseBounds = \case
     Ghc945   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
     Ghc946   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
     Ghc947   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
+    Ghc948   -> "base >= 4.15 && < 4.18" -- [ghc-9.0.1, ghc-9.6.1)
 
     -- require bytestring >= 0.11.3 which rules out ghc-9.2.1
     -- base-4.18.0
@@ -1392,7 +1393,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
         indent2 [ "compiler/cbits/genSym.c" ] ++
         indent2 [ "compiler/cbits/cutils.c" | ghcSeries ghcFlavor >= GHC_9_0 ] ++
         indent2 [ "compiler/parser/cutils.c" | ghcSeries ghcFlavor < GHC_9_0 ] ++
-        indent2 [ "compiler/cbits/keepCAFsForGHCi.c" | ghcFlavor `elem` [Ghc926, Ghc927, Ghc928, Ghc945, Ghc946, Ghc947] || ghcSeries ghcFlavor >= GHC_9_6 ] ++
+        indent2 [ "compiler/cbits/keepCAFsForGHCi.c" | ghcFlavor `elem` [Ghc926, Ghc927, Ghc928, Ghc945, Ghc946, Ghc947, Ghc948] || ghcSeries ghcFlavor >= GHC_9_6 ] ++
         [ "    hs-source-dirs:" ] ++
         indent2 (ghcLibParserHsSrcDirs False ghcFlavor lib) ++
         [ "    autogen-modules:" ] ++

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -13,7 +13,7 @@ data GhcFlavor = DaGhc881
                | Ghc8101 | Ghc8102 | Ghc8103 | Ghc8104 | Ghc8105 | Ghc8106 | Ghc8107
                | Ghc901 | Ghc902
                | Ghc921 | Ghc922 | Ghc923 | Ghc924 | Ghc925 | Ghc926 | Ghc927 | Ghc928
-               | Ghc941 | Ghc942 | Ghc943 | Ghc944 | Ghc945 | Ghc946 |  Ghc947
+               | Ghc941 | Ghc942 | Ghc943 | Ghc944 | Ghc945 | Ghc946 |  Ghc947 | Ghc948
                | Ghc961 | Ghc962 | Ghc963
                | Ghc981
                | GhcMaster

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -94,6 +94,7 @@ readFlavor = eitherReader $ \case
     "ghc-9.6.1" -> Right Ghc961
 
     -- ghc-9.4
+    "ghc-9.4.8" -> Right Ghc948
     "ghc-9.4.7" -> Right Ghc947
     "ghc-9.4.6" -> Right Ghc946
     "ghc-9.4.5" -> Right Ghc945


### PR DESCRIPTION
ghc-9.4.8 released nov-10 2023. ghc-lib-parser-9.4.8.20231111 and ghc-lib-9.4.8.20231111 pushed to hackage