### PR TITLE
ghc sources now assume GHC2021 extensions are in effect

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "c929f02bd0a1ff4c474ca18a03ac011d3394e291" -- 2024-01-09
+current = "9718d9707aee578eca63fc6735ae846a22c9904f" -- 2024-01-19
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -33,6 +33,7 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts resolve
         applyPatchHaddockHs ghcFlavor
         applyPatchNoMonoLocalBinds ghcFlavor
         applyPatchTemplateHaskellLanguageHaskellTHSyntax ghcFlavor
+        applyPatchTemplateHaskellLanguageHaskellTHSafe ghcFlavor
         generateGhcLibParserCabal ghcFlavor cppOpts
       Ghclib -> do
         when withInit $ init ghcFlavor


### PR DESCRIPTION
- default language GHC2021 comes in this MR https://gitlab.haskell.org/ghc/ghc/-/merge_requests/11743
  - 9.4 and 9.6 don't understand GHC2021 as a language but do support -XGHC2021 so use that
- also required to patch `Safe` out of template haskell modules (not immediately obvious why that has come up just now)
