### PR TITLE
rebase past showAstData fix

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -75,7 +75,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "d3a050d2a1eac0244f989badb3a2c75c84e0a160" -- 2024-02-28
+current = "2e592857b6e028fbad83712ceda6a0860191d379" -- 2024-03-09
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1178,11 +1178,12 @@ baseBounds = \case
     Ghc964   -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
 
     -- base-4.19.0.0, ghc-prim-0.11.0
-    Ghc981 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
-    Ghc982 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
+    Ghc981 -> "base >= 4.17 && < 4.19.1" -- [ghc-9.4.1, ghc-9.8.2)
+    -- base-4.19.1.0
+    Ghc982 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
     GhcMaster -- e.g. "9.9.20230119"
-              -- (c.f. 'rts/include/ghc-version.h')
-      -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.8.1)
+              -- (c.f. 'rts/include/ghcversion.h')
+      -> "base >= 4.18 && < 4.20" -- [ghc-9.6.1, ghc-9.10.1)
 
 -- Common build dependencies.
 commonBuildDepends :: GhcFlavor -> Data.List.NonEmpty.NonEmpty String


### PR DESCRIPTION
this gitlab GHC commit bfc09760b995b696fee598861ab4de32ec27e516 fixes breakage to `showAstData` after a recent EPA refactoring. it enables removing a fork of `GHC.Dump` on hlint's [ghc-next branch](https://github.com/ndmitchell/hlint/tree/ghc-next) to workaround some missing code.