### PR TITLE
update applyPatchTemplateHaskellCabal

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "1324b8626aeb4dc2d6a04f7605d307ef13d1e0e9" -- 2024-04-05
+current = "d7a3d6b5ee5e0c16af295579da3c54d8f0c37a05" -- 2024-04-17
 
 -- Command line argument generators.
 


### PR DESCRIPTION
update in light of commit 42bd040702d9a1c620354e7de05aaff6ee849f38. this requires a small tweak to one patch but enables dropping the `Language.Haskell.TH.Syntax` patch entirely (fixes https://github.com/digital-asset/ghc-lib/issues/468)!