### PR TITLE
add ghc-option -fno-safe-haskell to cabal files

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "d7a3d6b5ee5e0c16af295579da3c54d8f0c37a05" -- 2024-04-17
+current = "167a56a003106ed84742e3970cc2189ffb98b0c7" -- 2024-05-02
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -30,7 +30,6 @@ module Ghclibgen (
   , applyPatchCmmParseNoImplicitPrelude
   , applyPatchHadrianStackYaml
   , applyPatchTemplateHaskellLanguageHaskellTHSyntax
-  , applyPatchTemplateHaskellLanguageHaskellTHSafe
   , applyPatchTemplateHaskellCabal
   , applyPatchFptoolsAlex
   , applyPatchFpFindCxxStdLib
@@ -406,22 +405,6 @@ calcLibModules ghcFlavor = do
       modules = [ replace "/" "." . dropSuffix ".hs" $ m | m <- strippedModulePaths, m /= "Main.hs" ]
 
   return $ nubSort modules
-
-applyPatchTemplateHaskellLanguageHaskellTHSafe :: GhcFlavor -> IO ()
-applyPatchTemplateHaskellLanguageHaskellTHSafe ghcFlavor = do
-  when (ghcSeries ghcFlavor > GHC_9_8) $ do
-    let files =
-          [
-            "libraries/template-haskell/Language/Haskell/TH/Ppr.hs"
-          , "libraries/template-haskell/Language/Haskell/TH.hs"
-          ]
-    forM_ files $
-      \ file ->
-        writeFile file .
-        replace
-          "{-# LANGUAGE Safe #-}"
-          ""
-        =<< readFile' file
 
 applyPatchTemplateHaskellLanguageHaskellTHSyntax :: GhcFlavor -> IO ()
 applyPatchTemplateHaskellLanguageHaskellTHSyntax ghcFlavor = do
@@ -1352,6 +1335,7 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         , "    exposed: False"
         , "    include-dirs:"
         ] ++ indent2 (ghcLibIncludeDirs ghcFlavor) ++
+        [ "    ghc-options: -fno-safe-haskell" ] ++
         [ "    if flag(threaded-rts)"
         , "        ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
         , "        cc-options: -DTHREADED_RTS"
@@ -1447,6 +1431,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
         , "    default-language:   Haskell2010"
         , "    exposed: False"
         , "    include-dirs:"] ++ indent2 (ghcLibParserIncludeDirs ghcFlavor) ++
+        [ "    ghc-options: -fno-safe-haskell" ] ++
         [ "    if flag(threaded-rts)"
         , "        ghc-options: -fobject-code -package=ghc-boot-th -optc-DTHREADED_RTS"
         , "        cc-options: -DTHREADED_RTS"

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -33,7 +33,6 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts resolve
         applyPatchHaddockHs ghcFlavor
         applyPatchNoMonoLocalBinds ghcFlavor
         applyPatchTemplateHaskellLanguageHaskellTHSyntax ghcFlavor
-        applyPatchTemplateHaskellLanguageHaskellTHSafe ghcFlavor
         generateGhcLibParserCabal ghcFlavor cppOpts
       Ghclib -> do
         when withInit $ init ghcFlavor


### PR DESCRIPTION
[this refactor](https://gitlab.haskell.org/ghc/ghc/-/commit/4d78c53c527af05bc1b4944219fa88306449bae0) [broke ghc-lib-parser](https://github.com/shayne-fletcher/hlint-from-scratch/actions/runs/8916516869). the problem is we have been removing `Safe` from certain modules via code-mod. a better, less fragile approach is to to pass `-fno-safe-haskell` in the cabal ghc-options to ghc-lib-parser and ghc-lib which is what this PR does.