### PR TITLE
GHC >=9.10: depend on ghc-internal

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1446,6 +1446,8 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
         , "        build-depends: Win32"
         , "    build-depends:" ] ++
         indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibParserBuildDepends ghcFlavor))) ++
+        [ "    if impl(ghc >= 9.10)"
+        , "      build-depends: ghc-internal"] ++
         [ "    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20" ] ++
         [ "    other-extensions:" ] ++ indent2 (askField lib "other-extensions:") ++
         [ "    default-extensions:" ] ++ indent2 (askField lib "default-extensions:") ++


### PR DESCRIPTION
Otherwise, compiling ghc-lib-parser-9.10 with GHC 9.10 fails with
```
libraries/ghc-heap/GHC/Exts/Heap/ClosureTypes.hs:11:1: error: [GHC-87110]
    Could not load module ‘GHC.Internal.ClosureTypes’.
    It is a member of the hidden package ‘ghc-internal-9.1001.0’.
    Perhaps you need to add ‘ghc-internal’ to the build-depends in your .cabal file.
    Use -v to see a list of the files searched for.
   |
11 | import GHC.Internal.ClosureTypes
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```