### PR TITLE
foward compat ghc-9.10.1

### DIFF
--- a/.github/workflows/ghc-lib-runhaskell-ghc-9.10.1.yml
+++ b/.github/workflows/ghc-lib-runhaskell-ghc-9.10.1.yml
@@ -1,0 +1,34 @@
+name: ghc-lib-runhaskell-ghc-9.10.1
+on:
+  push:
+jobs:
+  ghc-9-10:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: 'latest'
+      - name: Upgrade stack from git
+        shell: bash
+        run: |-
+          stack upgrade --git
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          which stack
+          stack --version
+      - name: Install build tools
+        run: brew install automake
+        if: matrix.os == 'macos'
+      - name: Configure
+        shell: bash
+        # e.g. Don't recursively delete '.stack-work' (`stack clean --full`)
+        run: echo "GHCLIB_AZURE='1'" >> $GITHUB_ENV
+      - name: Run CI.hs
+        shell: bash
+        run: stack runhaskell --stack-yaml stack-exact.yaml --resolver ghc-9.8.2 --package extra --package optparse-applicative CI.hs -- --stack-yaml stack-exact.yaml --resolver ghc-9.8.2 --ghc-flavor "ghc-9.10.1"

--- a/CI.hs
+++ b/CI.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2019-20234 Digital Asset (Switzerland) GmbH and/or
+-- Copyright (c) 2019-2024 Digital Asset (Switzerland) GmbH and/or
 -- its affiliates. All rights reserved.  SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "1012e8aae57d1e61ea2f3b39ebe7bfa1ebe2dc0e" -- 2024-05-10
+current = "413217ba04b999313949b570a9386ca36e8ac82c" -- 2024-05-13
 
 -- Command line argument generators.
 

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -14,7 +14,8 @@ ghc-options:
   "$everything": -O0 -j
 
 # when you need it you need it
-#   allow-newer: true # e.g aeson's bounds on th-abstraction
+allow-newer: true # e.g aeson's bounds on th-abstraction
+# right now it's enabled because of testing with ghc-9.10
 
 extra-deps:
 # Dependencies of ghc-lib-parser & ghc-lib:
@@ -41,7 +42,7 @@ extra-deps:
 - ansi-wl-pprint-1.0.2
 - clock-0.8.4
 - colour-2.3.6
-- extra-1.7.14
+- extra-1.7.16
 - mintty-0.1.4
 - optparse-applicative-0.18.1.0
 - transformers-compat-0.7.2
@@ -89,14 +90,20 @@ extra-deps:
 - semigroupoids-6.0.0.1
 - strict-0.5
 - tagged-0.8.8
-- text-short-0.1.5
+# - text-short-0.1.5
+- github: shayne-fletcher/text-short
+  commit: "qualify-foldl"
 - th-abstraction-0.6.0.0
 - these-1.2
 - time-compat-1.9.6.1
 - unliftio-core-0.2.1.0
 - uuid-types-1.0.5.1
 - vector-0.13.1.0
-- vector-stream-0.1.0.0
+# - vector-stream-0.1.0.0
+- github: shayne-fletcher/vector
+  commit: "qualify-foldl"
+  subdirs:
+  - vector-stream
 - yaml-0.11.11.2
 - witherable-0.4.2
 - QuickCheck-2.14.3


### PR DESCRIPTION
this diff adds some package fixups that enable testing with ghc-9.10.1 as the build compiler. it also adds a github workflow for it that we can use as soon as a 9.10.1 resolver is made available (proxy with ghc-9.8.1 for the moment).