### PR TITLE
upgrade packages

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "413217ba04b999313949b570a9386ca36e8ac82c" -- 2024-05-13
+current = "e294f7a22412e3182a1ff8e101907d50bdb534a1" -- 2024-05-25
 
 -- Command line argument generators.
 

--- a/stack-exact.yaml
+++ b/stack-exact.yaml
@@ -7,15 +7,13 @@
 # You can add --resolver xxx to the above command to have the effect
 # of overriding the choice of compiler if desired.
 
-resolver: ghc-9.6.3
+resolver: ghc-9.10.1 # base == 4.20
 
 ghc-options:
   # Try to be quick.
   "$everything": -O0 -j
 
-# when you need it you need it
-allow-newer: true # e.g aeson's bounds on th-abstraction
-# right now it's enabled because of testing with ghc-9.10
+allow-newer: true # for unliftio-core => base<4.20
 
 extra-deps:
 # Dependencies of ghc-lib-parser & ghc-lib:
@@ -23,17 +21,18 @@ extra-deps:
 - happy-1.20.1.1
 # Dependencies for ghc-lib examples:
 - data-array-byte-0.1.0.1
-- hashable-1.4.3.0
+- hashable-1.4.4.0
+- os-string-2.0.3
 - syb-0.7.2.4
 - uniplate-1.6.13
 - unordered-containers-0.2.20
 # See https://gitlab.haskell.org/ghc/ghc/-/issues/23683
-- unix-2.8.5.0
-- directory-1.3.8.3
-- process-1.6.18.0
-- filepath-1.4.101.0
-- hpc-0.7.0.1
-- Win32-2.13.4.0
+- unix-2.8.5.1
+- directory-1.3.8.5
+- process-1.6.20.0
+- filepath-1.4.300.2
+- hpc-0.7.0.2
+- Win32-2.14.0.0
 - time-1.12.2
 - semaphore-compat-1.0.0
 # Additional dependencies for CI.hs & ghc-lib-gen:
@@ -47,38 +46,39 @@ extra-deps:
 - optparse-applicative-0.18.1.0
 - transformers-compat-0.7.2
 # ghc-lib-gen depdends on yaml
-- OneTuple-0.4.1.1
+- OneTuple-0.4.2
 - StateVar-1.2.2
-- assoc-1.1
+- assoc-1.1.1
 - base-compat-0.13.1
 - base-compat-batteries-0.13.1
-- base-orphans-0.9.1
+- base-orphans-0.9.2
 - contravariant-1.5.5
 - integer-logarithms-1.0.3.1
 - random-1.2.1.2
 - split-0.2.5
 - generically-0.1.1
 - bitvec-1.1.5.0
-- vector-algorithms-0.9.0.1
+- vector-algorithms-0.9.0.2
 - bifunctors-5.6.2
 - splitmix-0.1.0.5
 - distributive-0.6.2.1
 - comonad-5.0.8
-- aeson-2.2.1.0
+- aeson-2.2.2.0
+- character-ps-0.1
 - th-abstraction-0.6.0.0
-- integer-conversion-0.1.0.1
+- integer-conversion-0.1.1
 - network-uri-2.6.4.2
 - th-compat-0.1.5
-- text-iso8601-0.1
+- text-iso8601-0.1.1
 - text-2.1.1
 - parsec-3.1.17.0
 - attoparsec-0.14.4
 - conduit-1.3.5
-- data-fix-0.3.2
+- data-fix-0.3.3
 - dlist-1.0
 - foldable1-classes-compat-0.1
-- indexed-traversable-0.1.3
-- indexed-traversable-instances-0.1.1.2
+- indexed-traversable-0.1.4
+- indexed-traversable-instances-0.1.2
 - libyaml-0.1.4
 - libyaml-clib-0.2.5
 - mono-traversable-1.0.17.0
@@ -86,16 +86,16 @@ extra-deps:
 - prettyprinter-1.7.1
 - prettyprinter-ansi-terminal-1.1.3
 - resourcet-1.3.0
-- scientific-0.3.7.0
-- semialign-1.3
-- semigroupoids-6.0.0.1
+- scientific-0.3.8.0
+- semialign-1.3.1
+- semigroupoids-6.0.1
 - strict-0.5
 - tagged-0.8.8
 - text-short-0.1.6
-- these-1.2
-- time-compat-1.9.6.1
+- these-1.2.1
+- time-compat-1.9.7
 - unliftio-core-0.2.1.0
-- uuid-types-1.0.5.1
+- uuid-types-1.0.6
 - vector-0.13.1.0
 - vector-stream-0.1.0.1
 - yaml-0.11.11.2


### PR DESCRIPTION
with this `unliftio-core` remains preventing the removal of `allow-newer: true`