### PR TITLE
adapt to template haskell / ghc-internal changes

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "e294f7a22412e3182a1ff8e101907d50bdb534a1" -- 2024-05-25
+current = "bf0737c0b86a36ccc5523582dea6979e020fb547" -- 2024-05-31
 
 -- Command line argument generators.
 

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -32,6 +32,7 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts resolve
         applyPatchStage ghcFlavor
         applyPatchHaddockHs ghcFlavor
         applyPatchNoMonoLocalBinds ghcFlavor
+        applyPatchGhcInternalEventWindowsHsc ghcFlavor
         applyPatchTemplateHaskellLanguageHaskellTHSyntax ghcFlavor
         generateGhcLibParserCabal ghcFlavor cppOpts
       Ghclib -> do


### PR DESCRIPTION
MR https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12479 is about changes to support a "reinstallable" template haskell. this PR adapts as necessary to these changes.