### PR TITLE
tested at update to 118a12921a9ad3049420cdc67deb9c4ea2ccff23

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -76,7 +76,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "0cff083abb24701530974872b21cf897c9955a9a" -- 2024-06-03
+current = "118a12921a9ad3049420cdc67deb9c4ea2ccff23" -- 2024-06-16
 
 -- Command line argument generators.
 


### PR DESCRIPTION
see [this MR](https://gitlab.haskell.org/ghc/ghc/-/merge_requests/12889?commit_id=30802cd5942e69b6fa55b6a03d6b891ed5d868ec) for EPA changes to `mpats` in `Match`. hlint testing needs ghc-lib-parser to move past this commit.