### PR TITLE
add a cron job for master building from GHC HEAD

### DIFF
--- a/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.10.1.yml
+++ b/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.10.1.yml
@@ -1,0 +1,39 @@
+name: ghc-lib-ghc-HEAD-ghc-9.10.1
+on:
+  schedule: # run on master...
+  - cron:  '0 0 * * *' # .... once a day at midnight
+jobs:
+  runhaskell:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: 9.10.1
+          cabal-version: 'latest'
+      - name: Install build tools (macOS)
+        run: brew install automake
+        if: matrix.os == 'macos'
+      - name: Configure msys2 (windows)
+        shell: bash
+        run: |-
+          echo "MSYSTEM=CLANG64" >> $GITHUB_ENV
+          echo "/c/mingw64/usr/bin" >> $GITHUB_PATH
+          echo "/c/msys64/usr/bin" >> $GITHUB_PATH
+        if: matrix.os == 'windows'
+      - name: Run CI.hs (windows)
+        shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
+        run: |-
+          pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
+          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ""
+        if: matrix.os == 'windows'
+      - name: Run CI.hs (unix)
+        shell: bash
+        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ""
+        if: matrix.os == 'ubuntu' || matrix.os ==  'macos'


### PR DESCRIPTION
this workflow will give us an automated signal when a commit in GHC upstream breaks ghc-lib. the job it defines runs daily at 12:00am. it runs the ghc-lib CI process using the prevailing GHC HEAD commit.