### PR TITLE
bump tested at

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -96,7 +96,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "23f50640e705c132f1a0689d4850866d0f0d76a6" -- 2024-07-29
+current = "682a6a41626f9d9ef499080eb51189e92f130593" -- 2024-08-14
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case


### PR DESCRIPTION
hlint testing (see https://github.com/ndmitchell/hlint/actions/runs/10379774825) needs ghc-lib master flavor to move past commit 51ffba5d8eb53332c37a79966e66aa1a0a642523.