### PR TITLE
pass `-fno-safe-haskell` to the `ghc -M` commands 

### DIFF
--- a/.github/workflows/ghc-lib-ghc-8.10.1-8.8.1.yml
+++ b/.github/workflows/ghc-lib-ghc-8.10.1-8.8.1.yml
@@ -1,0 +1,39 @@
+name: ghc-lib-ghc-8.10.1-ghc-8.8.1
+on:
+  push:
+  pull_request:
+jobs:
+  runhaskell:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-13, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: 8.8.1
+          cabal-version: 'latest'
+      - name: Install build tools (macOS)
+        run: brew install automake
+        if: matrix.os == 'macos-13'
+      - name: Configure msys2 (windows)
+        shell: bash
+        run: |-
+          echo "MSYSTEM=CLANG64" >> $GITHUB_ENV
+          echo "/c/mingw64/usr/bin" >> $GITHUB_PATH
+          echo "/c/msys64/usr/bin" >> $GITHUB_PATH
+        if: matrix.os == 'windows-latest'
+      - name: Run CI.hs (windows)
+        shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
+        run: |-
+          pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
+          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-8.10.1
+        if: matrix.os == 'windows-latest'
+      - name: Run CI.hs (unix)
+        shell: bash
+        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-8.10.1
+        if: matrix.os == 'ubuntu-latest' || matrix.os ==  'macos-13'

--- a/CI.hs
+++ b/CI.hs
@@ -96,7 +96,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "682a6a41626f9d9ef499080eb51189e92f130593" -- 2024-08-14
+current = "1deba6b25f9b5bc4bc0bdb17431998cfcb47bac4" -- 2024-08-18
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -317,6 +317,7 @@ calcModuleDeps includeDirs _hsSrcDirs hsSrcIncludes ghcFlavor cabalPackageDb ghc
     [ ["ghc -M -dep-suffix '' -dep-makefile " ++ ghcMakeModeOutputFile],
       ["-clear-package-db -global-package-db -user-package-db -package-db " ++ cabalPackageDb],
       ["-package semaphore-compat" | series >= GHC_9_8],
+      ["-fno-safe-haskell" | series >= GHC_9_0], -- avoid warning: [GHC-98887] -XGeneralizedNewtypeDeriving is not allowed in Safe Haskell; ignoring -XGeneralizedNewtypeDeriving
       includeDirs,
       hsSrcIncludes,
       [placeholderModulesDir </> "Main.hs"]


### PR DESCRIPTION
- pass `-fno-safe-haskell` to the `ghc -M` commands to disable safe haskell checks and so extinguish  warnings like
```
<no location info>: warning: [GHC-98887]
    -XGeneralizedNewtypeDeriving is not allowed in Safe Haskell; ignoring -XGeneralizedNewtypeDeriving
```
- fill in a gap in the test matrix: ghc-lib-ghc-8.10.1-ghc-8.8.1
- bump last tested at