### PR TITLE
fix happy to 1.20.1.1

### DIFF
--- a/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.10.1.yml
+++ b/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.10.1.yml
@@ -35,5 +35,5 @@ jobs:
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)
         shell: bash
-        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ""
+        run: cabal run exe:ghc-lib-build-tool --constraint="any.happy==1.20.1.1" -- --ghc-flavor ""
         if: matrix.os == 'ubuntu' || matrix.os ==  'macos'


### PR DESCRIPTION
happy 2.0.1 was released yesterday https://hackage.haskell.org/package/happy-2.0.1as indicated by these build failures https://github.com/digital-asset/ghc-lib/actions/runs/10950791602, ghc bootstrapping requires happy <= 1.20.