### PR TITLE
fix happy to 1.20.1.1

### DIFF
--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -52,7 +52,7 @@ executable ghc-lib-gen
 
 executable ghc-lib-build-tool
   import: base
-  build-tool-depends: alex:alex, happy:happy
+  build-tool-depends: alex:alex, happy:happy < 2.0
   build-depends:
     directory, filepath, time, extra, optparse-applicative
   if flag(semaphore-compat)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1354,7 +1354,7 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         "    build-depends:"
       ],
       indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibBuildDepends ghcFlavor))),
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20"],
+      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20" ++ " && < 2.0"],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],
@@ -1464,7 +1464,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
       [ "    if impl(ghc >= 9.10)",
         "      build-depends: ghc-internal"
       ],
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20"],
+      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20" ++ " && < 2.0"],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],


### PR DESCRIPTION
happy 2.0.1 was released yesterday https://hackage.haskell.org/package/happy-2.0.1.

as indicated by these build failures https://github.com/digital-asset/ghc-lib/actions/runs/10950791602, ghc bootstrapping apparently demands happy <=happy-1.20.1.1
```
configure: error: Happy version 1.20 or earlier is required to compile GHC.
```

this PR adds the constraint `happy < 2.0` to `ghc-lib-gen.cabal` which enables us to recover working CI pipelines.

the same constraint is also added to (generated) ghc-lib/ghc-lib-parser cabal files which fixes https://github.com/digital-asset/ghc-lib/issues/557.