### PR TITLE
fix happy bounds

### DIFF
--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -52,7 +52,10 @@ executable ghc-lib-gen
 
 executable ghc-lib-build-tool
   import: base
-  build-tool-depends: alex:alex, happy:happy < 2.0
+  if impl (ghc > 9.12.0)
+    build-tool-depends: alex:alex, happy:happy == 1.20.* || >= 2.0.2 && < 2.1
+  else
+    build-tool-depends: alex:alex, happy:happy < 2.0
   build-depends:
     directory, filepath, time, extra, optparse-applicative
   if flag(semaphore-compat)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1283,6 +1283,13 @@ libBinParserLibModules ghcFlavor = do
     filterGhcInternalModules mods =
       [f | f <- mods, not ("GHC.Internal" `isPrefixOf` f) || (f `elem` keptGhcInternalModules)]
 
+happyBounds :: GhcFlavor -> String
+happyBounds ghcFlavor
+  | series < GHC_9_8 = "== 1.20.*"
+  | otherwise = "== 1.20.* || >= 2.0.2 && < 2.1" -- c.f. m4/fptools_happy.m4
+  where
+    series = ghcSeries ghcFlavor
+
 -- Produces a ghc-lib Cabal file.
 generateGhcLibCabal :: GhcFlavor -> [String] -> IO ()
 generateGhcLibCabal ghcFlavor customCppOpts = do
@@ -1357,7 +1364,7 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         "    build-depends:"
       ],
       indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibBuildDepends ghcFlavor))),
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20" ++ " && < 2.0"],
+      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy " ++ happyBounds ghcFlavor],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],
@@ -1467,7 +1474,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
       [ "    if impl(ghc >= 9.10)",
         "      build-depends: ghc-internal"
       ],
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy > " ++ if ghcSeries ghcFlavor < GHC_8_10 then "1.19" else "1.20" ++ " && < 2.0"],
+      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy " ++ happyBounds ghcFlavor],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],


### PR DESCRIPTION
motivation for this change discussed in https://github.com/digital-asset/ghc-lib/issues/563. for >=9.8 flavors, allow happy-2.0.2 in ghc-lib-parser build-tool-depends.

m4/fptools_happy.m4 informs configure which as of https://gitlab.haskell.org/ghc/ghc/-/commit/0029ca91c845dd4530eb2c4606ad5bd59775cec2 allows ==1.20.* || >= 2.0.2 && < 2.1