### PR TITLE
revert filepath lower bound updates

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1226,14 +1226,14 @@ commonBuildDepends ghcFlavor =
             "containers >= 0.6.2.1 && < 0.8",
             "bytestring >= 0.11.4 && < 0.13",
             "time >= 1.4 && < 1.15",
-            "filepath >= 1.5 && < 1.6"
+            "filepath >= 1 && < 1.6"
           ]
       | ghcSeries ghcFlavor >= GHC_9_8 =
           [ "ghc-prim > 0.2 && < 0.12",
             "containers >= 0.6.2.1 && < 0.8",
             "bytestring >= 0.11.4 && < 0.13",
             "time >= 1.4 && < 1.15",
-            "filepath >= 1.5 && < 1.6"
+            "filepath >= 1 && < 1.6"
           ]
       | ghcSeries ghcFlavor >= GHC_9_6 =
           [ "ghc-prim > 0.2 && < 0.11",


### PR DESCRIPTION
in https://github.com/digital-asset/ghc-lib/pull/571 i raised the lower bound on filepath to 1.5 for ghc-9.8 and ghc-9.10 flavors to be consistent with GHC itself. this had the negative effects described in https://github.com/digital-asset/ghc-lib/issues/572 so this PR undoes that change.