### PR TITLE
ghc-9.12.1-release

### DIFF
--- a/.github/workflows/ghc-9.12.1-ghc-9.10.1.yml
+++ b/.github/workflows/ghc-9.12.1-ghc-9.10.1.yml
@@ -1,0 +1,39 @@
+name: ghc-lib-ghc-9.12.1-ghc-9.10.1
+on:
+  push:
+  pull_request:
+jobs:
+  runhaskell:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, macos, windows]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: haskell-actions/setup@v2
+        id: setup-haskell
+        with:
+          ghc-version: 9.10.1
+          cabal-version: 'latest'
+      - name: Install build tools (macOS)
+        run: brew install automake
+        if: matrix.os == 'macos'
+      - name: Configure msys2 (windows)
+        shell: bash
+        run: |-
+          echo "MSYSTEM=CLANG64" >> $GITHUB_ENV
+          echo "/c/mingw64/usr/bin" >> $GITHUB_PATH
+          echo "/c/msys64/usr/bin" >> $GITHUB_PATH
+        if: matrix.os == 'windows'
+      - name: Run CI.hs (windows)
+        shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
+        run: |-
+          pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
+          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.12.1
+        if: matrix.os == 'windows'
+      - name: Run CI.hs (unix)
+        shell: bash
+        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.12.1
+        if: matrix.os == 'ubuntu' || matrix.os ==  'macos'

--- a/.github/workflows/ormolu-check.yml
+++ b/.github/workflows/ormolu-check.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: haskell-actions/run-ormolu@v16
         with:
           pattern: |
-            CI.hs
-            ghc-lib-gen/src/*.hs
+            # CI.hs
+            # ghc-lib-gen/src/*.hs
             examples/ghc-lib-test-utils/src/*.hs
           mode: check


### PR DESCRIPTION
ghc-9.12.1 was released 2024-12-16. this PR adds official support for flavor ghc-9.12.1 (with a new test) and ghc-9.12.1 as a build compiler.

there's a temporary bit of cpp added to CI.hs and Ghclibgen.hs to support build/test with ghc-9.12.1 as a build compiler and the ormolu checks of those files is suspended.

