### PR TITLE
restrict alex < 3.5.2.0

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -100,7 +100,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "8b266671bcfe9ef5a25f0a78ea7dcca68b78dc32" -- 2024-12-19
+current = "278a53ee698d961d97afb60be9db2d8bf60b4074" -- 2024-12-30
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
@@ -358,19 +358,13 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
       pkg_ghclib_parser = "ghc-lib-parser-" ++ version
       ghcFlavorArg = ghcFlavorOpt ghcFlavor
 
-#if __GLASGOW_HASKELL__ < 912
-  let extraCabalFlags = ""
-#else
-  let extraCabalFlags = "--allow-newer=\"hashable:base,unordered-containers:template-haskell\" "
-#endif
-
-  system_ $ "cabal build " ++ extraCabalFlags ++ "exe:ghc-lib-gen"
-  system_ $ "cabal run " ++ extraCabalFlags ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib-parser " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor
+  system_ $ "cabal build " ++ "exe:ghc-lib-gen"
+  system_ $ "cabal run " ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib-parser " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor
   patchVersion version "ghc/ghc-lib-parser.cabal"
   mkTarball pkg_ghclib_parser
   renameDirectory pkg_ghclib_parser "ghc-lib-parser"
   removeFile "ghc/ghc-lib-parser.cabal"
-  system_ $ "cabal run " ++ extraCabalFlags ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor ++ " --skip-init"
+  system_ $ "cabal run " ++ "exe:ghc-lib-gen -- ghc ../patches --ghc-lib " ++ ghcFlavorArg ++ " " ++ cppOpts ghcFlavor ++ " --skip-init"
   patchVersion version "ghc/ghc-lib.cabal"
   patchConstraints version "ghc/ghc-lib.cabal"
   mkTarball pkg_ghclib

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -53,9 +53,9 @@ executable ghc-lib-gen
 executable ghc-lib-build-tool
   import: base
   if impl (ghc > 9.12.0)
-    build-tool-depends: alex:alex, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
+    build-tool-depends: alex:alex < 3.5.2.0, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
   else
-    build-tool-depends: alex:alex, happy:happy < 2.0
+    build-tool-depends: alex:alex < 3.5.2.0, happy:happy < 2.0
   build-depends:
     directory, filepath, time, extra, optparse-applicative
   if flag(semaphore-compat)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1314,7 +1314,7 @@ libBinParserLibModules ghcFlavor = do
 
 happyBounds :: GhcFlavor -> String
 happyBounds ghcFlavor
-  | series < GHC_9_8 = "== 1.20.*"
+  | series < GHC_9_8 = "< 1.21"
   | otherwise = "== 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2" -- c.f. m4/fptools_happy.m4
   where
     series = ghcSeries ghcFlavor
@@ -1393,7 +1393,7 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         "    build-depends:"
       ],
       indent2 (Data.List.NonEmpty.toList (withCommas (ghcLibBuildDepends ghcFlavor))),
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy " ++ happyBounds ghcFlavor],
+      ["    build-tool-depends: alex:alex >= 3.1 && < 3.5.2.0, " ++ "happy:happy " ++ happyBounds ghcFlavor],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],
@@ -1513,7 +1513,7 @@ generateGhcLibParserCabal ghcFlavor customCppOpts = do
       [ "    if impl(ghc >= 9.10)",
         "      build-depends: ghc-internal"
       ],
-      ["    build-tool-depends: alex:alex >= 3.1, " ++ "happy:happy " ++ happyBounds ghcFlavor],
+      ["    build-tool-depends: alex:alex >= 3.1 && < 3.5.2.0, " ++ "happy:happy " ++ happyBounds ghcFlavor],
       ["    other-extensions:"],
       indent2 (askField lib "other-extensions:"),
       ["    default-extensions:"],


### PR DESCRIPTION
alex-3.5.2.0 was released to hackage on 2024-12-30. it produces errors like this
```
compiler/GHC/Parser/Lexer.x:3471:12: error: [GHC-31744]
    Duplicate INLINE pragmas for ‘alexScanUser’
    at /home/runner/work/ghc-lib/ghc-lib/dist-newstyle/build/x86_64-linux/ghc-9.10.1/ghc-lib-parser-0.20241231/build/GHC/Parser/Lexer.hs:1383:12-23
       compiler/GHC/Parser/Lexer.x:3471:12-23
     |
3471 | -- in this file, alexScanUser gets broken out into a separate function and
     |            ^^^^^^^^^^^^
```
on flavors >= ghc-9.12.1 e.g. https://github.com/digital-asset/ghc-lib/actions/runs/12553438884. verified that this is a problem for GHC too. see https://github.com/haskell/alex/issues/266.

incidentally, remove `extraCabalFlags` from CI.hs (they are needed any more) and slightly modify the happy bounds for ghc < 9.8 to workaround a build failure for workflow ghc-flavor 9.0.2 with build compiler 8.10.7 (i have no idea why that decided to break just now).

