### PR TITLE
fix CPP guards around ghc_unique_counter64

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -100,7 +100,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "278a53ee698d961d97afb60be9db2d8bf60b4074" -- 2024-12-30
+current = "595013d41464c1e328369bb81ce0ea2814e91b68" -- 2025-01-24
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -942,8 +942,12 @@ mangleCSymbols ghcFlavor = do
    in writeFile file
         . prefixSymbol genSym
         . prefixSymbol initGenSym
-        . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
-        =<< readFile' file
+          =<< readFile' file
+  when (ghcFlavor <= Ghc9121) $
+    let file = "compiler/cbits/genSym.c"
+    in writeFile file
+       . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
+       =<< readFile' file
   when (ghcFlavor == Ghc984) $
     let file = "compiler/cbits/genSym.c"
      in writeFile file


### PR DESCRIPTION
[compiler: Fix CPP guards around ghc_unique_counter64](https://gitlab.haskell.org/ghc/ghc/-/commit/595013d41464c1e328369bb81ce0ea2814e91b68) 