### PR TITLE
remove empty hs-source-dirs from ghc-lib

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -101,7 +101,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "07fe6d1daad01030cb7b9e6897492b7bdaec5a90" -- 2025-03-06
+current = "c758cb7154e54893af2221960eac543f98550e55" -- 2025-03-15
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1456,9 +1456,6 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
         then
           join [
                  ["    if impl(ghc < 9.12.1)"],
-                 ["      hs-source-dirs:"],
-                 ["        libraries/ghc-internal/src"],
-                 ["        libraries/ghc-boot-th-internal"],
                  ["      reexported-modules:"],
                  indent3 (Data.List.NonEmpty.toList (withCommas (Data.List.NonEmpty.fromList [ "GHC.Internal.ForeignSrcLang", "GHC.Internal.LanguageExtensions", "GHC.Internal.Lexeme", "GHC.Internal.TH.Syntax"])))
                ]
@@ -1467,9 +1464,6 @@ generateGhcLibCabal ghcFlavor customCppOpts = do
           then
             join [
                    ["    if impl(ghc < 9.12.1)"],
-                   ["      hs-source-dirs:"],
-                   ["        libraries/ghc-internal/src"],
-                   ["        libraries/ghc-boot-th-internal"],
                    ["      reexported-modules:"],
                    indent3 (Data.List.NonEmpty.toList (withCommas (Data.List.NonEmpty.fromList [  "GHC.Internal.ForeignSrcLang", "GHC.Internal.LanguageExtensions", "GHC.Internal.Lexeme", "GHC.Internal.TH.Syntax", "GHC.Internal.TH.Ppr", "GHC.Internal.TH.PprLib", "GHC.Internal.TH.Lib.Map"])))
                ]


### PR DESCRIPTION
hackage blocks uploading packages when a cabal file contains empty source directories.