### PR TITLE
ghc-9.6.7

### DIFF
--- a/.github/workflows/ghc-9.8.4-ghc-9.6.7.yml
+++ b/.github/workflows/ghc-9.8.4-ghc-9.6.7.yml
@@ -1,4 +1,4 @@
-name: ghc-lib-ghc-9.6.6-ghc-9.4.8
+name: ghc-lib-ghc-9.8.4-ghc-9.6.7
 on:
   push:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.4.8
+          ghc-version: 9.6.7
           cabal-version: 'latest'
       - name: Install build tools (macOS)
         run: brew install automake
@@ -31,9 +31,9 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
         run: |-
           pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
-          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.6.6
+          cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.4
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)
         shell: bash
-        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.6.6
+        run: cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.4
         if: matrix.os == 'ubuntu' || matrix.os ==  'macos'

--- a/.github/workflows/ghc-lib-ghc-9.6.7-ghc-9.4.8.yml
+++ b/.github/workflows/ghc-lib-ghc-9.6.7-ghc-9.4.8.yml
@@ -1,4 +1,4 @@
-name: ghc-lib-ghc-9.8.4-ghc-9.6.5
+name: ghc-lib-ghc-9.6.7-ghc-9.4.8
 on:
   push:
   pull_request:
@@ -15,7 +15,7 @@ jobs:
       - uses: haskell-actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.6.5
+          ghc-version: 9.4.8
           cabal-version: 'latest'
       - name: Install build tools (macOS)
         run: brew install automake
@@ -31,9 +31,9 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
         run: |-
           pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
-          cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.4
+          cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.6.7
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)
         shell: bash
-        run: cabal run exe:ghc-lib-build-tool --constraint='ghc-lib-gen +semaphore-compat' -- --ghc-flavor ghc-9.8.4
+        run: cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-9.6.7
         if: matrix.os == 'ubuntu' || matrix.os ==  'macos'

--- a/CI.hs
+++ b/CI.hs
@@ -1,5 +1,4 @@
-
--- Copyright (c) 2019-2024 Digital Asset (Switzerland) GmbH and/or
+-- Copyright (c) 2019-2025 Digital Asset (Switzerland) GmbH and/or
 -- its affiliates. All rights reserved.  SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 -- CI script, compatible with all of Travis, Appveyor and Azure.
@@ -54,6 +53,7 @@ data GhcFlavor
   | Ghc983
   | Ghc982
   | Ghc981
+  | Ghc967
   | Ghc966
   | Ghc965
   | Ghc964
@@ -102,7 +102,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "25d46547f8767475d8ab98cac07c78571848ef18" -- 2025-03-19
+current = "3bc507db6906fc415aa0b91fec4b5feb8d3dd03c" -- 2025-03-24
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
@@ -114,6 +114,7 @@ ghcFlavorOpt = \case
   Ghc983 -> "--ghc-flavor ghc-9.8.3"
   Ghc982 -> "--ghc-flavor ghc-9.8.2"
   Ghc981 -> "--ghc-flavor ghc-9.8.1"
+  Ghc967 -> "--ghc-flavor ghc-9.6.7"
   Ghc966 -> "--ghc-flavor ghc-9.6.6"
   Ghc965 -> "--ghc-flavor ghc-9.6.5"
   Ghc964 -> "--ghc-flavor ghc-9.6.4"
@@ -181,6 +182,7 @@ genVersionStr flavor suffix =
       Ghc983 -> "9.8.3"
       Ghc982 -> "9.8.2"
       Ghc981 -> "9.8.1"
+      Ghc967 -> "9.6.7"
       Ghc966 -> "9.6.6"
       Ghc965 -> "9.6.5"
       Ghc964 -> "9.6.4"
@@ -252,6 +254,7 @@ parseOptions =
       "ghc-9.8.3" -> Right Ghc983
       "ghc-9.8.2" -> Right Ghc982
       "ghc-9.8.1" -> Right Ghc981
+      "ghc-9.6.7" -> Right Ghc967
       "ghc-9.6.6" -> Right Ghc966
       "ghc-9.6.5" -> Right Ghc965
       "ghc-9.6.4" -> Right Ghc964
@@ -524,6 +527,7 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
       Ghc983 -> "ghc-9.8.3-release"
       Ghc982 -> "ghc-9.8.2-release"
       Ghc981 -> "ghc-9.8.1-release"
+      Ghc967 -> "ghc-9.6.7-release"
       Ghc966 -> "ghc-9.6.6-release"
       Ghc965 -> "ghc-9.6.5-release"
       Ghc964 -> "ghc-9.6.4-release"

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2021-2022 Digital Asset (Switzerland) GmbH and/or its
+-- Copyright (c) 2021-2025 Digital Asset (Switzerland) GmbH and/or its
 -- affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 {-# LANGUAGE LambdaCase #-}
@@ -54,6 +54,7 @@ data GhcVersion
   | Ghc963
   | Ghc964
   | Ghc965
+  | Ghc967
   | Ghc966
   | Ghc981
   | Ghc982
@@ -143,6 +144,7 @@ readFlavor =
     "ghc-9.8.2" -> Just Ghc982
     "ghc-9.8.1" -> Just Ghc981
     -- ghc-9.6
+    "ghc-9.6.7" -> Just Ghc967
     "ghc-9.6.6" -> Just Ghc966
     "ghc-9.6.5" -> Just Ghc965
     "ghc-9.6.4" -> Just Ghc964

--- a/ghc-lib-gen.cabal
+++ b/ghc-lib-gen.cabal
@@ -9,7 +9,7 @@ x-license: BSD-3-Clause OR Apache-2.0
 license-file: LICENSE
 author: Shayne Fletcher (shayne@shaynefletcher.org)
 maintainer: Shayne Fletcher (shayne@shaynefletcher.org)
-copyright: Digital Asset 2018-2024
+copyright: Digital Asset 2018-2025
 category: Development
 build-type: Simple
 
@@ -52,10 +52,13 @@ executable ghc-lib-gen
 
 executable ghc-lib-build-tool
   import: base
-  if impl (ghc > 9.12.0)
-    build-tool-depends: alex:alex, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
+  if impl(ghc == 9.6.7)
+    build-tool-depends: alex:alex, happy:happy == 1.20.*
   else
-    build-tool-depends: alex:alex, happy:happy < 2.0
+    if impl(ghc > 9.12.0)
+      build-tool-depends: alex:alex, happy:happy == 1.20.* || == 2.0.2 || >= 2.1.2 && < 2.2
+    else
+      build-tool-depends: alex:alex, happy:happy < 2.0
   build-depends:
     directory, filepath, time, extra, optparse-applicative
   if flag(semaphore-compat)

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2019-2024, Digital Asset (Switzerland) GmbH and/or
+-- Copyright (c) 2019-2025, Digital Asset (Switzerland) GmbH and/or
 -- its affiliates. All rights reserved.  SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 {-# LANGUAGE CPP #-}
@@ -966,7 +966,7 @@ mangleCSymbols ghcFlavor = do
   when (ghcFlavor <= Ghc9121) $
     let file = "compiler/cbits/genSym.c"
     in writeFile file
-       . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
+       . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,6,7,0)"
        =<< readFile' file
   when (ghcFlavor == Ghc984) $
     let file = "compiler/cbits/genSym.c"
@@ -1226,6 +1226,7 @@ baseBounds = \case
   Ghc964 -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
   Ghc965 -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
   Ghc966 -> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
+  Ghc967-> "base >= 4.16.1 && < 4.19" -- [ghc-9.2.2, ghc-9.8.1)
 
   -- base-4.19.0.0, ghc-prim-0.11.0
   Ghc981 -> "base >= 4.17 && < 4.19.1" -- [ghc-9.4.1, ghc-9.8.2)

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2019 - 2023 Digital Asset (Switzerland) GmbH and/or
+-- Copyright (c) 2019-2025 Digital Asset (Switzerland) GmbH and/or
 -- its affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 {-# LANGUAGE LambdaCase #-}
@@ -46,6 +46,7 @@ data GhcFlavor
   | Ghc963
   | Ghc964
   | Ghc965
+  | Ghc967
   | Ghc966
   | Ghc981
   | Ghc982

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2019 - 2023 Digital Asset (Switzerland) GmbH and/or
+-- Copyright (c) 2019-2025 Digital Asset (Switzerland) GmbH and/or
 -- its affiliates. All rights reserved. SPDX-License-Identifier:
 -- (Apache-2.0 OR BSD-3-Clause)
 {-# LANGUAGE LambdaCase #-}
@@ -105,6 +105,7 @@ readFlavor = eitherReader $ \case
   "ghc-9.8.2" -> Right Ghc982
   "ghc-9.8.1" -> Right Ghc981
   -- ghc-9.6
+  "ghc-9.6.7" -> Right Ghc967
   "ghc-9.6.6" -> Right Ghc966
   "ghc-9.6.5" -> Right Ghc965
   "ghc-9.6.4" -> Right Ghc964


### PR DESCRIPTION
ghc-9.6.7 was released 2025-03-24 and ghc-lib-parser-9.6.7.20250325 and ghc-lib-9.6.7.20250325 uploaded to hackage.