### PR TITLE
fix multiple declarations of ghc_unique_counter64

### DIFF
--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -963,11 +963,15 @@ mangleCSymbols ghcFlavor = do
         . prefixSymbol genSym
         . prefixSymbol initGenSym
           =<< readFile' file
-  when (ghcFlavor <= Ghc9121) $
-    let file = "compiler/cbits/genSym.c"
-    in writeFile file
-       . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,6,7,0)"
-       =<< readFile' file
+  let file = "compiler/cbits/genSym.c"
+      replacement = "#if !MIN_VERSION_GLASGOW_HASKELL(9,6,7,0)\n"
+                        <> "HsWord64 ghc_unique_counter64 = 0;\n"
+                        <> "#elif MIN_VERSION_GLASGOW_HASKELL(9,8,0,0) "
+                        <> "&& !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"
+   in writeFile file
+        . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)" replacement
+        . replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" replacement
+        =<< readFile' file
   when (ghcFlavor == Ghc984) $
     let file = "compiler/cbits/genSym.c"
      in writeFile file


### PR DESCRIPTION
Fixes #595 .

So this is basically your patch. I removed the guard about ghcFlavor because we need it for Ghc9122 too.

One thing: unless I'm mistaken, this mike cause issues for people using ghc-9.8.0 to 9.8.3 as the offending patch has only been backported to ghc-9.8.4. If this is something you care about, then we would need something like

. replace "#if !MIN_VERSION_GLASGOW_HASKELL(9,9,0,0)" "#if !MIN_VERSION_GLASGOW_HASKELL(9,6,7,0) || !MIN_VERSION_GLASGOW_HASKELL(9,8,0) && !MIN_VERSION_GLASGOW_HASKELL(9,8,4,0)"

What do you think?