### PR TITLE
thread 'allow-newer' flags

### DIFF
--- a/CI.hs
+++ b/CI.hs
@@ -48,6 +48,7 @@ data GhcFlavor
   | Ghc9141
   | Ghc9122
   | Ghc9121
+  | Ghc9103
   | Ghc9102
   | Ghc9101
   | Ghc985
@@ -104,13 +105,14 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "9d626be140de24004414188aa5fee74187d255e5" -- 2025-09-05
+current = "80a07571623a6fe7692c08dbdee440ff90ce98c2" -- 2025-09-11
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case
   Ghc9141 -> "--ghc-flavor ghc-9.14.1"
   Ghc9122 -> "--ghc-flavor ghc-9.12.2"
   Ghc9121 -> "--ghc-flavor ghc-9.12.1"
+  Ghc9103 -> "--ghc-flavor ghc-9.10.3"
   Ghc9102 -> "--ghc-flavor ghc-9.10.2"
   Ghc9101 -> "--ghc-flavor ghc-9.10.1"
   Ghc985 -> "--ghc-flavor ghc-9.8.5"
@@ -181,6 +183,7 @@ genVersionStr flavor suffix =
       Ghc9141 -> "9.14.1"
       Ghc9122 -> "9.12.2"
       Ghc9121 -> "9.12.1"
+      Ghc9103 -> "9.10.3"
       Ghc9102 -> "9.10.2"
       Ghc9101 -> "9.10.1"
       Ghc985 -> "9.8.5"
@@ -255,6 +258,7 @@ parseOptions =
       "ghc-9.14.1" -> Right Ghc9141
       "ghc-9.12.2" -> Right Ghc9122
       "ghc-9.12.1" -> Right Ghc9121
+      "ghc-9.10.3" -> Right Ghc9103
       "ghc-9.10.2" -> Right Ghc9102
       "ghc-9.10.1" -> Right Ghc9101
       "ghc-9.8.5" -> Right Ghc985
@@ -532,6 +536,7 @@ buildDists ghcFlavor noGhcCheckout noBuilds versionSuffix = do
       Ghc9141 -> "ghc-9.14"
       Ghc9122 -> "ghc-9.12.2-release"
       Ghc9121 -> "ghc-9.12.1-release"
+      Ghc9103 -> "ghc-9.10.3-release"
       Ghc9102 -> "ghc-9.10.2-release"
       Ghc9101 -> "ghc-9.10.1-release"
       Ghc985 -> "ghc-9.8"

--- a/examples/ghc-lib-test-utils/src/TestUtils.hs
+++ b/examples/ghc-lib-test-utils/src/TestUtils.hs
@@ -63,6 +63,7 @@ data GhcVersion
   | Ghc985
   | Ghc9101
   | Ghc9102
+  | Ghc9103
   | Ghc9121
   | Ghc9122
   | Ghc9141
@@ -80,6 +81,7 @@ showGhcVersion = \case
   Ghc9141 -> "ghc-9.14.1"
   Ghc9122 -> "ghc-9.12.2"
   Ghc9121 -> "ghc-9.12.1"
+  Ghc9103 -> "ghc-9.10.3"
   Ghc9102 -> "ghc-9.10.2"
   Ghc9101 -> "ghc-9.10.1"
   Ghc985 -> "ghc-9.8.5"
@@ -143,6 +145,7 @@ readFlavor =
     "ghc-9.12.2" -> Just Ghc9122
     "ghc-9.12.1" -> Just Ghc9121
     -- ghc-9.10
+    "ghc-9.10.3" -> Just Ghc9103
     "ghc-9.10.2" -> Just Ghc9102
     "ghc-9.10.1" -> Just Ghc9101
     -- ghc-9.8

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -136,6 +136,7 @@ ghcLibParserHsSrcDirs forDepends ghcFlavor lib =
         case ghcSeries ghcFlavor of
           GHC_8_8 -> ["compiler/codeGen", "compiler/hieFile", "compile/llvmGen", "compiler/stranal", "compiler/rename", "compiler/stgSyn", "compiler/llvmGen"]
           GHC_8_10 -> ["compiler/nativeGen", "compiler/deSugar", "compiler/hieFile", "compiler/llvmGen", "compiler/stranal", "compiler/rename", "compiler/stgSyn"]
+          GHC_9_10 -> ["libraries/ghc-internal/src"]
           _ -> []
   in sortDiffListByLength all $ Set.fromList [dir | not forDepends, dir <- exclusions]
 
@@ -152,7 +153,7 @@ ghcLibHsSrcDirs forDepends ghcFlavor lib =
           GHC_9_4 -> ["ghc-lib/stage0/libraries/ghc-boot/build", "libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-heap", "libraries/ghci"]
           GHC_9_6 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghci"]
           GHC_9_8 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform"]
-          GHC_9_10 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci"]
+          GHC_9_10 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci", "libraries/ghc-internal/src"]
           GHC_9_12 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci"]
           GHC_9_14 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci"]
           GHC_9_16 -> ["libraries/template-haskell", "libraries/ghc-boot-th", "libraries/ghc-boot", "", "libraries/ghc-heap", "libraries/ghc-platform/src", "libraries/ghc-platform", "libraries/ghci", "libraries/ghc-internal"]
@@ -1346,6 +1347,7 @@ baseBounds = \case
   Ghc984 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
   Ghc985 -> "base >= 4.17 && < 4.20" -- [ghc-9.4.1, ghc-9.10.1)
   -- base-4.20.0.0
+  Ghc9103 -> "base >= 4.18 && < 4.21" -- [ghc-9.6.1, ghc-9.12.1)
   Ghc9102 -> "base >= 4.18 && < 4.21" -- [ghc-9.6.1, ghc-9.12.1)
   Ghc9101 -> "base >= 4.18 && < 4.21" -- [ghc-9.6.1, ghc-9.12.1)
   -- base-4.21.0.0

--- a/ghc-lib-gen/src/GhclibgenFlavor.hs
+++ b/ghc-lib-gen/src/GhclibgenFlavor.hs
@@ -55,6 +55,7 @@ data GhcFlavor
   | Ghc985
   | Ghc9101
   | Ghc9102
+  | Ghc9103
   | Ghc9121
   | Ghc9122
   | Ghc9141

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -32,7 +32,8 @@ data GhclibgenOpts = GhclibgenOpts
     ghclibgenOpts_ghcFlavor :: !GhcFlavor,
     ghclibgenOpts_skipInit :: !Bool,
     ghclibgenOpts_customCppFlags :: ![String],
-    ghclibgenOpts_stackResolver :: !(Maybe String)
+    ghclibgenOpts_stackResolver :: !(Maybe String),
+    ghclibgenOpts_allowNewer :: ![String]
   }
 
 -- | A parser of the "--ghc-lib" target.
@@ -80,6 +81,7 @@ ghclibgenOpts =
       )
     <*> cppCustomFlagsOpt
     <*> stackResolverOpt
+    <*> allowNewerOpt
 
 ghcFlavorOpt :: Parser GhcFlavor
 ghcFlavorOpt =
@@ -88,6 +90,13 @@ ghcFlavorOpt =
     ( long "ghc-flavor"
         <> help "The ghc-flavor to test against"
     )
+
+allowNewerOpt :: Parser [String]
+allowNewerOpt =
+  many $ strOption
+    ( long "allow-newer"
+   <> metavar "SPEC"
+   <> help "Pass --allow-newer=SPEC to cabal (repeatable). Use SPEC=all for all packages." )
 
 readFlavor :: ReadM GhcFlavor
 readFlavor = eitherReader $ \case

--- a/ghc-lib-gen/src/GhclibgenOpts.hs
+++ b/ghc-lib-gen/src/GhclibgenOpts.hs
@@ -99,6 +99,7 @@ readFlavor = eitherReader $ \case
   "ghc-9.12.2" -> Right Ghc9122
   "ghc-9.12.1" -> Right Ghc9121
   -- ghc-9.10
+  "ghc-9.10.3" -> Right Ghc9103
   "ghc-9.10.2" -> Right Ghc9102
   "ghc-9.10.1" -> Right Ghc9101
   -- ghc-9.8

--- a/ghc-lib-gen/src/Main.hs
+++ b/ghc-lib-gen/src/Main.hs
@@ -22,7 +22,7 @@ main = ghclibgen =<< execParser opts
         )
 
 ghclibgen :: GhclibgenOpts -> IO ()
-ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts _resolver) = do
+ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts _resolver allowNewer) = do
   withCurrentDirectory root $
     case target of
       GhclibParser -> do
@@ -58,7 +58,7 @@ ghclibgen (GhclibgenOpts root _patches target ghcFlavor skipInit cppOpts _resolv
       applyPatchAclocal ghcFlavor -- Do before ./boot && ./configure
       applyPatchFptoolsAlex ghcFlavor
       applyPatchFpFindCxxStdLib ghcFlavor
-      generatePrerequisites ghcFlavor
+      generatePrerequisites ghcFlavor allowNewer
       -- Renamings come after 'generatePrerequisites':
       applyPatchDerivedConstants ghcFlavor -- Needs DerivedConstants.h
       applyPatchHsVersions ghcFlavor


### PR DESCRIPTION
**rebase on master after https://github.com/digital-asset/ghc-lib/pull/609 lands**

thread `--allow-newer` flags through to nested cabal commands

this allows us to new alpha compiler releases e.g. build ghc_lib-flavor ghc-9.14.1 w/ build compiler ghc-9.14.0.20250908 (zsh)
```
rm cabal.project&&typeset -a GHC_LIB_ALLOW_NEWER=(
  --allow-newer=hashable:containers
  --allow-newer=hashable:ghc-bignum
  --allow-newer=hashable:base
  --allow-newer=unordered-containers:template-haskell
  --allow-newer=primitive:base
  --allow-newer=tagged:template-haskell
  )
cabal run exe:ghc-lib-build-tool "${GHC_LIB_ALLOW_NEWER[@]}" -- --ghc-flavor ghc-9.14.1 --no-checkout "${GHC_LIB_ALLOW_NEWER[@]}"
```