### PR TITLE
use system libffi

### DIFF
--- a/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.12.1.yml
+++ b/.github/workflows/ghc-lib-ghc-HEAD-ghc-9.12.1.yml
@@ -20,17 +20,21 @@ jobs:
       - name: Install build tools (macOS)
         run: brew install automake
         if: matrix.os == 'macos'
+      - name: Install build tools (ubuntu)
+        run: sudo apt-get update && sudo apt-get install -y libffi-dev
+        if: matrix.os == 'ubuntu'
       - name: Configure msys2 (windows)
         shell: bash
         run: |-
           echo "MSYSTEM=CLANG64" >> $GITHUB_ENV
+          echo "/c/msys64/clang64/bin" >> $GITHUB_PATH
           echo "/c/mingw64/usr/bin" >> $GITHUB_PATH
           echo "/c/msys64/usr/bin" >> $GITHUB_PATH
         if: matrix.os == 'windows'
       - name: Run CI.hs (windows)
         shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
         run: |-
-          pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
+          pacman -S autoconf automake-wrapper make patch python tar mintty mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-pkgconf --noconfirm
           cabal run exe:ghc-lib-build-tool -- --ghc-flavor ""
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)

--- a/.github/workflows/ghc-lib-ghc-master-ghc-9.12.1.yml
+++ b/.github/workflows/ghc-lib-ghc-master-ghc-9.12.1.yml
@@ -20,17 +20,21 @@ jobs:
       - name: Install build tools (macOS)
         run: brew install automake
         if: matrix.os == 'macos'
+      - name: Install build tools (ubuntu)
+        run: sudo apt-get update && sudo apt-get install -y libffi-dev
+        if: matrix.os == 'ubuntu'
       - name: Configure msys2 (windows)
         shell: bash
         run: |-
           echo "MSYSTEM=CLANG64" >> $GITHUB_ENV
+          echo "/c/msys64/clang64/bin" >> $GITHUB_PATH
           echo "/c/mingw64/usr/bin" >> $GITHUB_PATH
           echo "/c/msys64/usr/bin" >> $GITHUB_PATH
         if: matrix.os == 'windows'
       - name: Run CI.hs (windows)
         shell: C:\msys64\usr\bin\bash.exe --noprofile --norc -e -o pipefail '{0}'
         run: |-
-          pacman -S autoconf automake-wrapper make patch python tar mintty --noconfirm
+          pacman -S autoconf automake-wrapper make patch python tar mintty mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-pkgconf --noconfirm
           cabal run exe:ghc-lib-build-tool -- --ghc-flavor ghc-master
         if: matrix.os == 'windows'
       - name: Run CI.hs (unix)

--- a/CI.hs
+++ b/CI.hs
@@ -110,7 +110,7 @@ data DaFlavor = DaFlavor
 
 -- Last tested gitlab.haskell.org/ghc/ghc.git at
 current :: String
-current = "7b9c20f4c3c82a534d22bb56e6bebf2ec0491a82" -- 2025-12-28
+current = "b18b2c42c32488ad6d3480a56a1fcd753cad2023" -- 2026-01-17
 
 ghcFlavorOpt :: GhcFlavor -> String
 ghcFlavorOpt = \case

--- a/ghc-lib-gen/src/Ghclibgen.hs
+++ b/ghc-lib-gen/src/Ghclibgen.hs
@@ -65,6 +65,7 @@ import System.Directory
 import System.Directory.Extra
 import System.FilePath hiding (dropTrailingPathSeparator, normalise, (</>))
 import System.FilePath.Posix (dropTrailingPathSeparator, normalise, (</>))
+import System.Info (os)
 import System.IO.Error (isEOFError)
 import System.IO.Extra
 import System.Process.Extra
@@ -1785,7 +1786,27 @@ generatePrerequisites ghcFlavor allowNewerSpecs = do
     )
 
   system_ "bash -c ./boot"
-  system_ "bash -c \"./configure --enable-tarballs-autodownload\""
+  ffiArgs <- if ghcSeries ghcFlavor >= GHC_9_16
+    then do
+      -- GHC 9.16+ bundles libffi-clib by default; we need to use
+      -- system libffi instead. On macOS, use xcrun to find the SDK
+      -- path (pkg-config often has stale paths). On other platforms,
+      -- use pkg-config.
+      (ffiIncludeDir, ffiLibDir) <-
+        if os == "darwin"
+          then do
+            -- macOS: use xcrun to find the SDK path (pkg-config often has stale paths)
+            sdkPath <- trim <$> systemOutput_ "xcrun --show-sdk-path"
+            pure (sdkPath ++ "/usr/include/ffi", "/usr/lib")
+          else do
+            -- Linux/Windows: use pkg-config
+            inc <- trim <$> systemOutput_ "pkg-config --variable=includedir libffi"
+            lib <- trim <$> systemOutput_ "pkg-config --variable=libdir libffi"
+            pure (inc, lib)
+      pure ["--with-system-libffi", "--with-ffi-includes=" ++ ffiIncludeDir, "--with-ffi-libraries=" ++ ffiLibDir]
+    else pure []
+  let configureArgs = unwords $ ["--enable-tarballs-autodownload"] ++ ffiArgs
+  system_ $ "bash -c \"./configure " ++ configureArgs ++ "\""
   withCurrentDirectory "hadrian" $ do
 
     let allowNewerArgs = mkAllowNewerFlagsList allowNewerSpecs


### PR DESCRIPTION
[hlint-from-scratch](https://github.com/shayne-fletcher/hlint-from-scratch) builds discovered the ghc-lib build was broken by https://gitlab.haskell.org/ghc/ghc/-/commit/0f53ccc6ef7560ec72b3b489b533a8ae9c6c86c1 landed 5 days ago. this fixes it.

this hasn't surfaced in the ghc-lib build because it hasn't run due to needing re-enablement for more than 30 days as pointed out in https://github.com/digital-asset/ghc-lib/issues/626

cc @nycnewman @dylant-da